### PR TITLE
PFS-29: Switching invoice type out to enum style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ go-lint:
 build:
 	docker compose build --no-cache --parallel finance-hub finance-api finance-migration
 
+build-dev:
+	docker compose -f docker-compose.yml -f docker/docker-compose.dev.yml build --no-cache --parallel finance-hub finance-api
+
 build-all:
 	docker compose build --parallel finance-hub finance-api finance-migration json-server cypress sirius-db
 

--- a/finance-hub/web/template/update-invoice.gotmpl
+++ b/finance-hub/web/template/update-invoice.gotmpl
@@ -33,10 +33,10 @@
                                     <div class="govuk-radios" >
                                         {{ range .InvoiceTypes }}
                                             <div class="govuk-radios__item">
-                                                <input class="govuk-radios__input {{ if .AmountRequired }}show{{else}}hide{{ end }}-input-field" id="{{.Handle}}" name="invoiceType"
-                                                       type="radio" value="{{.Handle}}">
+                                                <input class="govuk-radios__input {{ if .AmountRequired }}show{{else}}hide{{ end }}-input-field" id="{{.Key}}" name="invoiceType"
+                                                       type="radio" value="{{.Key}}">
                                                 <label class="govuk-label govuk-radios__label"
-                                                       for="{{.Handle}}">{{.Description}}</label>
+                                                       for="{{.Key}}">{{.Translation}}</label>
                                             </div>
                                         {{ end }}
                                     </div>

--- a/shared/invoice_type.go
+++ b/shared/invoice_type.go
@@ -1,15 +1,63 @@
 package shared
 
-type InvoiceType struct {
-	Handle         string
-	Description    string
-	AmountRequired bool
+var InvoiceTypes = []InvoiceType{
+	WriteOff,
+	AddCredit,
+	AddDebit,
+	Unapply,
+	Reapply,
 }
 
-var InvoiceTypes = []InvoiceType{
-	{Handle: "writeOff", Description: "Write off", AmountRequired: false},
-	{Handle: "addCredit", Description: "Add credit", AmountRequired: true},
-	{Handle: "addDebit", Description: "Add debit", AmountRequired: true},
-	{Handle: "unapply", Description: "Unapply", AmountRequired: true},
-	{Handle: "reapply", Description: "Reapply", AmountRequired: true},
+type InvoiceType int
+
+const (
+	Unknown InvoiceType = iota
+	WriteOff
+	AddCredit
+	AddDebit
+	Unapply
+	Reapply
+)
+
+func (i InvoiceType) Translation() string {
+	switch i {
+	case WriteOff:
+		return "Write off"
+	case AddCredit:
+		return "Add credit"
+	case AddDebit:
+		return "Add debit"
+	case Unapply:
+		return "Unapply"
+	case Reapply:
+		return "Reapply"
+	default:
+		return ""
+	}
+}
+
+func (i InvoiceType) Key() string {
+	switch i {
+	case WriteOff:
+		return "CREDIT WRITE OFF" // ?
+	case AddCredit:
+		return "CREDIT MEMO" // ?
+	case AddDebit:
+		return "UNKNOWN DEBIT" // ?
+	case Unapply:
+		return "UNAPPLY" // ?
+	case Reapply:
+		return "REAPPLY" // ?
+	default:
+		return ""
+	}
+}
+
+func (i InvoiceType) AmountRequired() bool {
+	switch i {
+	case AddCredit, AddDebit, Unapply, Reapply:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
Golang has a glaring lack of enums but there are workarounds. This demonstrates one approach, and allows the invoice types to be typed and encode information in the shared package for use in both services.