### PR TITLE
pfs-104: Adds in public schema for assignees table access [DO NOT MERGE]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,5 +127,4 @@ services:
       DB_PASSWORD: password
       DB_CONNECTION: sirius-db:5432
       DB_NAME: finance
-      DB_SCHEMA: supervision_finance
     command: "up"

--- a/docker/finance-migration/migrate.sh
+++ b/docker/finance-migration/migrate.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-DB_CONN_STR="postgres://$DB_USER:$DB_PASSWORD@$DB_CONNECTION/$DB_NAME?search_path=$DB_SCHEMA"
+DB_CONN_STR="postgres://$DB_USER:$DB_PASSWORD@$DB_CONNECTION/$DB_NAME"
 COMMAND=$1
 
 check_var() {
@@ -19,7 +19,6 @@ check_var DB_USER $DB_USER
 check_var DB_PASSWORD $DB_PASSWORD
 check_var DB_CONNECTION $DB_CONNECTION
 check_var DB_NAME $DB_NAME
-check_var DB_SCHEMA $DB_SCHEMA
 check_var COMMAND $1
 
 /usr/local/bin/goose -dir /database postgres $DB_CONN_STR $COMMAND

--- a/finance-api/internal/service/add_fee_reduction.go
+++ b/finance-api/internal/service/add_fee_reduction.go
@@ -50,13 +50,13 @@ func (s *Service) AddFeeReduction(id int, data shared.AddFeeReduction) error {
 
 	transaction := s.store.WithTx(tx)
 
-	var feeReduction store.FeeReduction
+	var feeReduction store.SupervisionFinanceFeeReduction
 	feeReduction, err = transaction.AddFeeReduction(ctx, addFeeReductionQueryArgs)
 	if err != nil {
 		return err
 	}
 
-	var invoices []store.Invoice
+	var invoices []store.SupervisionFinanceInvoice
 	invoices, err = transaction.AddFeeReductionToInvoices(ctx, feeReduction.ID)
 	if err != nil {
 		return err
@@ -85,7 +85,7 @@ func (s *Service) AddFeeReduction(id int, data shared.AddFeeReduction) error {
 				//TODO make sure we have correct createdby ID in ticket PFS-88
 				CreatedbyID: pgtype.Int4{Int32: 1},
 			}
-			var ledger store.Ledger
+			var ledger store.SupervisionFinanceLedger
 			ledger, err = transaction.CreateLedgerForFeeReduction(ctx, ledgerQueryArgs)
 			if err != nil {
 				return err

--- a/finance-api/internal/service/add_fee_reduction_test.go
+++ b/finance-api/internal/service/add_fee_reduction_test.go
@@ -36,6 +36,7 @@ func (suite *IntegrationSuite) TestService_AddFeeReduction() {
 	conn := suite.testDB.GetConn()
 
 	conn.SeedData(
+		"SET SEARCH_PATH to supervision_finance;",
 		"INSERT INTO finance_client VALUES (22, 22, '1234', 'DEMANDED', NULL);",
 		"INSERT INTO fee_reduction VALUES (22, 22, 'REMISSION', NULL, '2019-04-01', '2021-03-31', 'Remission to see the notes', FALSE, '2019-05-01');",
 	)
@@ -77,6 +78,7 @@ func (suite *IntegrationSuite) TestService_AddFeeReductionOverlap() {
 	conn := suite.testDB.GetConn()
 
 	conn.SeedData(
+		"SET SEARCH_PATH to supervision_finance;",
 		"INSERT INTO finance_client VALUES (23, 23, '1234', 'DEMANDED', NULL);",
 		"INSERT INTO fee_reduction VALUES (23, 23, 'REMISSION', NULL, '2019-04-01', '2021-03-31', 'Remission to see the notes', FALSE, '2019-05-01');",
 	)

--- a/finance-api/internal/service/cancel_fee_reduction_test.go
+++ b/finance-api/internal/service/cancel_fee_reduction_test.go
@@ -12,6 +12,7 @@ func (suite *IntegrationSuite) TestService_CancelFeeReduction() {
 	conn := suite.testDB.GetConn()
 
 	conn.SeedData(
+		"SET SEARCH_PATH to supervision_finance;",
 		"INSERT INTO finance_client VALUES (33, 33, '1234', 'DEMANDED', NULL);",
 		"INSERT INTO fee_reduction VALUES (33, 33, 'REMISSION', NULL, '2019-04-01', '2021-03-31', 'Remission to see the notes', FALSE, '2019-05-01');",
 	)

--- a/finance-api/internal/service/fee_reductions_test.go
+++ b/finance-api/internal/service/fee_reductions_test.go
@@ -14,6 +14,7 @@ func (suite *IntegrationSuite) TestService_GetFeeReductions() {
 	conn := suite.testDB.GetConn()
 
 	conn.SeedData(
+		"SET SEARCH_PATH to supervision_finance;",
 		"INSERT INTO finance_client VALUES (5, 5, '1234', 'DEMANDED', NULL);",
 		"INSERT INTO fee_reduction VALUES (5, 5, 'REMISSION', NULL, '2019-04-01', '2020-03-31', 'Remission to see the notes', FALSE, '2019-05-01');",
 	)

--- a/finance-api/internal/service/finance_clients_test.go
+++ b/finance-api/internal/service/finance_clients_test.go
@@ -11,6 +11,7 @@ func (suite *IntegrationSuite) TestService_GetAccountInformation() {
 	conn := suite.testDB.GetConn()
 
 	conn.SeedData(
+		"SET SEARCH_PATH to supervision_finance;",
 		"INSERT INTO finance_client VALUES (1, 1, 'sop123', 'DEMANDED', NULL)",
 		"INSERT INTO finance_client VALUES (3, 3, 'sop123', 'DEMANDED', NULL)",
 		"INSERT INTO invoice VALUES (1, 1, 1, 'S2', 'S203531/19', '2019-04-01', '2020-03-31', 32000, NULL, '2020-03-20',1, '2020-03-16', 10, NULL, 0, '2019-06-06', 99);",

--- a/finance-api/internal/service/invoice_adjustments_test.go
+++ b/finance-api/internal/service/invoice_adjustments_test.go
@@ -12,6 +12,7 @@ func (suite *IntegrationSuite) TestService_GetInvoiceAdjustments() {
 	conn := suite.testDB.GetConn()
 
 	conn.SeedData(
+		"SET SEARCH_PATH to supervision_finance;",
 		"INSERT INTO finance_client VALUES (6, 6, '1234', 'DEMANDED', NULL);",
 		"INSERT INTO ledger VALUES (2, 'abc1', '2022-04-02T00:00:00+00:00', '', 12300, 'first credit', 'CREDIT MEMO', 'REJECTED', 6, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '05/05/2022', 1);",
 		"INSERT INTO ledger VALUES (3, 'def2', '2022-04-03T00:00:00+00:00', '', 23001, 'first write off', 'CREDIT WRITE OFF', 'CONFIRMED', 6, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '05/05/2022', 1);",

--- a/finance-api/internal/service/invoices_test.go
+++ b/finance-api/internal/service/invoices_test.go
@@ -13,6 +13,7 @@ func (suite *IntegrationSuite) TestService_GetInvoices() {
 	conn := suite.testDB.GetConn()
 
 	conn.SeedData(
+		"SET SEARCH_PATH to supervision_finance;",
 		"INSERT INTO finance_client VALUES (7, 1, '1234', 'DEMANDED', NULL);",
 		"INSERT INTO finance_client VALUES (3, 2, '1234', 'DEMANDED', NULL);",
 		"INSERT INTO fee_reduction VALUES (2, 7, 'REMISSION', NULL, '2019-04-01'::DATE, '2020-03-31'::DATE, 'notes', FALSE, '2019-05-01'::DATE);",

--- a/finance-api/internal/service/ledger_entries_test.go
+++ b/finance-api/internal/service/ledger_entries_test.go
@@ -14,6 +14,7 @@ func (suite *IntegrationSuite) TestService_CreateLedgerEntry() {
 	conn := suite.testDB.GetConn()
 
 	conn.SeedData(
+		"SET SEARCH_PATH to supervision_finance;",
 		"INSERT INTO finance_client VALUES (1, 1, '1234', 'DEMANDED', NULL);",
 		"INSERT INTO invoice VALUES (1, 1, 1, 'S2', 'S204642/19', '2022-04-02', '2022-04-02', 32000, NULL, NULL, NULL, NULL, NULL, NULL, 0, '2022-04-02', 1);",
 		"INSERT INTO ledger VALUES (1, 'abc1', '2022-04-02T00:00:00+00:00', '', 22000, 'Initial payment', 'UNKNOWN DEBIT', 'CONFIRMED', 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '05/05/2022', 1);",
@@ -73,13 +74,13 @@ func (suite *IntegrationSuite) TestService_CreateLedgerEntry() {
 				return
 			}
 
-			var ledger store.Ledger
+			var ledger store.SupervisionFinanceLedger
 			q := conn.QueryRow(context.Background(), "SELECT id, amount, notes, type, status, finance_client_id FROM ledger WHERE id = 2")
 			err = q.Scan(&ledger.ID, &ledger.Amount, &ledger.Notes, &ledger.Type, &ledger.Status, &ledger.FinanceClientID)
 			if err != nil {
 				assert.ErrorIs(t, err, tt.err)
 			} else {
-				expected := store.Ledger{
+				expected := store.SupervisionFinanceLedger{
 					ID:              2,
 					Amount:          int32(tt.data.Amount),
 					Notes:           pgtype.Text{String: tt.data.AdjustmentNotes, Valid: true},
@@ -91,13 +92,13 @@ func (suite *IntegrationSuite) TestService_CreateLedgerEntry() {
 				assert.EqualValues(t, expected, ledger)
 			}
 
-			var la store.LedgerAllocation
+			var la store.SupervisionFinanceLedgerAllocation
 			q = conn.QueryRow(context.Background(), "SELECT id, ledger_id, invoice_id, amount, status, notes FROM ledger_allocation WHERE id = 2")
 			err = q.Scan(&la.ID, &la.LedgerID, &la.InvoiceID, &la.Amount, &la.Status, &la.Notes)
 			if err != nil {
 				assert.ErrorIs(t, err, tt.err)
 			} else {
-				expected := store.LedgerAllocation{
+				expected := store.SupervisionFinanceLedgerAllocation{
 					ID:        2,
 					LedgerID:  pgtype.Int4{Int32: int32(2), Valid: true},
 					InvoiceID: pgtype.Int4{Int32: int32(1), Valid: true},

--- a/finance-api/internal/service/update_pending_invoice_adjustment_test.go
+++ b/finance-api/internal/service/update_pending_invoice_adjustment_test.go
@@ -11,6 +11,7 @@ func (suite *IntegrationSuite) TestService_UpdatePendingInvoiceAdjustment() {
 	conn := suite.testDB.GetConn()
 
 	conn.SeedData(
+		"SET SEARCH_PATH to supervision_finance;",
 		"INSERT INTO finance_client VALUES (15, 15, '1234', 'DEMANDED', NULL);",
 		"INSERT INTO invoice VALUES (15, 15, 15, 'S2', 'S203531/19', '2019-04-01', '2020-03-31', 12300, NULL, '2020-03-20',1, '2020-03-16', 10, NULL, 12300, '2019-06-06', NULL);",
 		"INSERT INTO ledger VALUES (15, 'random1223', '2022-04-11T08:36:40+00:00', '', 12300, '', 'CREDIT MEMO', 'PENDING', 15, 15, NULL, '11/04/2022', '12/04/2022', 1254, '', '', 1, '05/05/2022', 65);",

--- a/finance-api/internal/store/finance_client.sql.go
+++ b/finance-api/internal/store/finance_client.sql.go
@@ -11,14 +11,15 @@ import (
 
 const getAccountInformation = `-- name: GetAccountInformation :one
 WITH balances AS (SELECT i.id, fc.client_id, i.amount, COALESCE(SUM(la.amount), 0) paid
-FROM finance_client fc
-         LEFT JOIN invoice i ON fc.id = i.finance_client_id
-         LEFT JOIN ledger_allocation la ON i.id = la.invoice_id AND la.status IN ('ALLOCATED', 'APPROVED')
-WHERE fc.client_id = $1
-GROUP BY i.id, fc.client_id)
+                  FROM supervision_finance.finance_client fc
+                           LEFT JOIN supervision_finance.invoice i ON fc.id = i.finance_client_id
+                           LEFT JOIN supervision_finance.ledger_allocation la
+                                     ON i.id = la.invoice_id AND la.status IN ('ALLOCATED', 'APPROVED')
+                  WHERE fc.client_id = $1
+                  GROUP BY i.id, fc.client_id)
 SELECT COALESCE(SUM(balances.amount), 0) - SUM(balances.paid) outstanding, 0 credit, fc.payment_method
-FROM finance_client fc
-JOIN balances ON fc.client_id = balances.client_id
+FROM supervision_finance.finance_client fc
+         JOIN balances ON fc.client_id = balances.client_id
 WHERE fc.client_id = $1
 GROUP BY fc.payment_method
 `

--- a/finance-api/internal/store/invoice_fee_range.sql.go
+++ b/finance-api/internal/store/invoice_fee_range.sql.go
@@ -12,9 +12,10 @@ import (
 )
 
 const getInvoiceFeeRangeAmount = `-- name: GetInvoiceFeeRangeAmount :one
-select sum(amount) / 2
-from invoice_fee_range
-where invoice_id = $1 and supervisionlevel = $2
+SELECT SUM(amount) / 2
+FROM supervision_finance.invoice_fee_range
+WHERE invoice_id = $1
+  AND supervisionlevel = $2
 `
 
 type GetInvoiceFeeRangeAmountParams struct {

--- a/finance-api/internal/store/invoices.sql.go
+++ b/finance-api/internal/store/invoices.sql.go
@@ -12,31 +12,29 @@ import (
 )
 
 const addFeeReductionToInvoices = `-- name: AddFeeReductionToInvoices :many
-WITH filtered_invoices AS (
-    SELECT i.id AS invoice_id, fr.id AS fee_reduction_id
-    FROM invoice i
-             JOIN fee_reduction fr
-                  ON i.finance_client_id = fr.finance_client_id
-    WHERE i.raiseddate >= (fr.datereceived - interval '6 months')
-      AND i.raiseddate BETWEEN fr.startdate AND fr.enddate
-      AND fr.id = $1
-)
-UPDATE invoice i
+WITH filtered_invoices AS (SELECT i.id AS invoice_id, fr.id AS fee_reduction_id
+                           FROM supervision_finance.invoice i
+                                    JOIN supervision_finance.fee_reduction fr
+                                         ON i.finance_client_id = fr.finance_client_id
+                           WHERE i.raiseddate >= (fr.datereceived - INTERVAL '6 months')
+                             AND i.raiseddate BETWEEN fr.startdate AND fr.enddate
+                             AND fr.id = $1)
+UPDATE supervision_finance.invoice i
 SET fee_reduction_id = fi.fee_reduction_id
 FROM filtered_invoices fi
 WHERE i.id = fi.invoice_id
-returning i.id, i.person_id, i.finance_client_id, i.feetype, i.reference, i.startdate, i.enddate, i.amount, i.supervisionlevel, i.confirmeddate, i.batchnumber, i.raiseddate, i.source, i.scheduledfn14date, i.cacheddebtamount, i.createddate, i.createdby_id, i.fee_reduction_id
+RETURNING i.id, i.person_id, i.finance_client_id, i.feetype, i.reference, i.startdate, i.enddate, i.amount, i.supervisionlevel, i.confirmeddate, i.batchnumber, i.raiseddate, i.source, i.scheduledfn14date, i.cacheddebtamount, i.createddate, i.createdby_id, i.fee_reduction_id
 `
 
-func (q *Queries) AddFeeReductionToInvoices(ctx context.Context, id int32) ([]Invoice, error) {
+func (q *Queries) AddFeeReductionToInvoices(ctx context.Context, id int32) ([]SupervisionFinanceInvoice, error) {
 	rows, err := q.db.Query(ctx, addFeeReductionToInvoices, id)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Invoice
+	var items []SupervisionFinanceInvoice
 	for rows.Next() {
-		var i Invoice
+		var i SupervisionFinanceInvoice
 		if err := rows.Scan(
 			&i.ID,
 			&i.PersonID,
@@ -69,11 +67,11 @@ func (q *Queries) AddFeeReductionToInvoices(ctx context.Context, id int32) ([]In
 
 const getInvoiceBalance = `-- name: GetInvoiceBalance :one
 SELECT i.amount initial, i.amount - COALESCE(SUM(la.amount), 0) outstanding, i.feetype
-FROM invoice i
-         LEFT JOIN ledger_allocation la on i.id = la.invoice_id
+FROM supervision_finance.invoice i
+         LEFT JOIN supervision_finance.ledger_allocation la on i.id = la.invoice_id
     AND la.status IN ('ALLOCATED', 'APPROVED')
 WHERE i.id = $1
-group by i.amount, i.feetype
+GROUP BY i.amount, i.feetype
 `
 
 type GetInvoiceBalanceRow struct {
@@ -90,10 +88,11 @@ func (q *Queries) GetInvoiceBalance(ctx context.Context, id int32) (GetInvoiceBa
 }
 
 const getInvoices = `-- name: GetInvoices :many
-SELECT i.id, i.reference, i.amount, i.raiseddate, COALESCE(SUM(la.amount), 0)::int received
-FROM invoice i
-         JOIN finance_client fc ON fc.id = i.finance_client_id
-         LEFT JOIN ledger_allocation la ON i.id = la.invoice_id AND la.status IN ('ALLOCATED', 'APPROVED')
+SELECT i.id, i.reference, i.amount, i.raiseddate, COALESCE(SUM(la.amount), 0)::INT received
+FROM supervision_finance.invoice i
+         JOIN supervision_finance.finance_client fc ON fc.id = i.finance_client_id
+         LEFT JOIN supervision_finance.ledger_allocation la
+                   ON i.id = la.invoice_id AND la.status IN ('ALLOCATED', 'APPROVED')
 WHERE fc.client_id = $1
 GROUP BY i.id, i.raiseddate
 ORDER BY i.raiseddate DESC
@@ -134,11 +133,11 @@ func (q *Queries) GetInvoices(ctx context.Context, clientID int32) ([]GetInvoice
 }
 
 const getLedgerAllocations = `-- name: GetLedgerAllocations :many
-select la.id, la.amount, la.datetime, l.bankdate, l.type, la.status
-from ledger_allocation la
-         inner join ledger l on la.ledger_id = l.id
-where la.invoice_id = $1
-order by la.id desc
+SELECT la.id, la.amount, la.datetime, l.bankdate, l.type, la.status
+FROM supervision_finance.ledger_allocation la
+         INNER JOIN supervision_finance.ledger l ON la.ledger_id = l.id
+WHERE la.invoice_id = $1
+ORDER BY la.id DESC
 `
 
 type GetLedgerAllocationsRow struct {
@@ -178,10 +177,10 @@ func (q *Queries) GetLedgerAllocations(ctx context.Context, invoiceID pgtype.Int
 }
 
 const getSupervisionLevels = `-- name: GetSupervisionLevels :many
-select supervisionlevel, fromdate, todate, amount
-from invoice_fee_range
-where invoice_id = $1
-order by todate desc
+SELECT supervisionlevel, fromdate, todate, amount
+FROM supervision_finance.invoice_fee_range
+WHERE invoice_id = $1
+ORDER BY todate DESC
 `
 
 type GetSupervisionLevelsRow struct {

--- a/finance-api/internal/store/ledger.sql.go
+++ b/finance-api/internal/store/ledger.sql.go
@@ -12,11 +12,12 @@ import (
 )
 
 const createLedger = `-- name: CreateLedger :one
-WITH fc AS (SELECT id FROM finance_client WHERE client_id = $1),
+WITH fc AS (SELECT id FROM supervision_finance.finance_client WHERE client_id = $1),
      ledger AS (
-         INSERT INTO ledger (id, datetime, amount, notes, type, finance_client_id, reference, method, status)
-             SELECT nextval('ledger_id_seq'),
-                    now(),
+         INSERT INTO supervision_finance.ledger (id, datetime, amount, notes, type, finance_client_id, reference,
+                                                 method, status)
+             SELECT NEXTVAL('supervision_finance.ledger_id_seq'),
+                    NOW(),
                     $3,
                     $4,
                     $5,
@@ -27,8 +28,8 @@ WITH fc AS (SELECT id FROM finance_client WHERE client_id = $1),
              FROM fc
              RETURNING id, datetime)
 INSERT
-INTO ledger_allocation (id, ledger_id, invoice_id, datetime, amount, status, notes)
-SELECT nextval('ledger_allocation_id_seq'),
+INTO supervision_finance.ledger_allocation (id, ledger_id, invoice_id, datetime, amount, status, notes)
+SELECT NEXTVAL('supervision_finance.ledger_allocation_id_seq'),
        ledger.id,
        $2,
        ledger.datetime,
@@ -36,7 +37,7 @@ SELECT nextval('ledger_allocation_id_seq'),
        'PENDING',
        $4
 FROM ledger
-returning (SELECT reference invoiceReference FROM invoice WHERE id = invoice_id)
+RETURNING (SELECT reference invoicereference FROM supervision_finance.invoice WHERE id = invoice_id)
 `
 
 type CreateLedgerParams struct {
@@ -61,12 +62,14 @@ func (q *Queries) CreateLedger(ctx context.Context, arg CreateLedgerParams) (str
 }
 
 const createLedgerForFeeReduction = `-- name: CreateLedgerForFeeReduction :one
-insert into ledger (id, reference, datetime, method, amount, notes, type, status, finance_client_id,
-                    parent_id, fee_reduction_id, confirmeddate, bankdate, batchnumber, bankaccount,
-                    line, source,
-                    createddate, createdby_id)
-VALUES (nextval('ledger_id_seq'::regclass), gen_random_uuid(), now(), $1, $2, $3, $4, 'Status', $5, null, $6, null,
-        null, null, null, null, null, now(), $7) returning id, reference, datetime, method, amount, notes, type, status, finance_client_id, parent_id, fee_reduction_id, confirmeddate, bankdate, batchnumber, bankaccount, source, line, createddate, createdby_id
+INSERT INTO supervision_finance.ledger (id, reference, datetime, method, amount, notes, type, status, finance_client_id,
+                                        parent_id, fee_reduction_id, confirmeddate, bankdate, batchnumber, bankaccount,
+                                        line, source,
+                                        createddate, createdby_id)
+VALUES (NEXTVAL('supervision_finance.ledger_id_seq'::REGCLASS), gen_random_uuid(), NOW(), $1, $2, $3, $4, 'Status', $5,
+        NULL, $6, NULL,
+        NULL, NULL, NULL, NULL, NULL, NOW(), $7)
+RETURNING id, reference, datetime, method, amount, notes, type, status, finance_client_id, parent_id, fee_reduction_id, confirmeddate, bankdate, batchnumber, bankaccount, source, line, createddate, createdby_id
 `
 
 type CreateLedgerForFeeReductionParams struct {
@@ -79,7 +82,7 @@ type CreateLedgerForFeeReductionParams struct {
 	CreatedbyID     pgtype.Int4
 }
 
-func (q *Queries) CreateLedgerForFeeReduction(ctx context.Context, arg CreateLedgerForFeeReductionParams) (Ledger, error) {
+func (q *Queries) CreateLedgerForFeeReduction(ctx context.Context, arg CreateLedgerForFeeReductionParams) (SupervisionFinanceLedger, error) {
 	row := q.db.QueryRow(ctx, createLedgerForFeeReduction,
 		arg.Method,
 		arg.Amount,
@@ -89,7 +92,7 @@ func (q *Queries) CreateLedgerForFeeReduction(ctx context.Context, arg CreateLed
 		arg.FeeReductionID,
 		arg.CreatedbyID,
 	)
-	var i Ledger
+	var i SupervisionFinanceLedger
 	err := row.Scan(
 		&i.ID,
 		&i.Reference,
@@ -115,7 +118,7 @@ func (q *Queries) CreateLedgerForFeeReduction(ctx context.Context, arg CreateLed
 }
 
 const updateLedgerAdjustment = `-- name: UpdateLedgerAdjustment :exec
-UPDATE ledger l
+UPDATE supervision_finance.ledger l
 SET status = $1
 WHERE l.id = $2
 `

--- a/finance-api/internal/store/ledger_allocation.sql.go
+++ b/finance-api/internal/store/ledger_allocation.sql.go
@@ -12,10 +12,10 @@ import (
 )
 
 const createLedgerAllocationForFeeReduction = `-- name: CreateLedgerAllocationForFeeReduction :one
-INSERT INTO ledger_allocation (id, ledger_id, invoice_id, datetime, amount, status, reference,
+INSERT INTO supervision_finance.ledger_allocation (id, ledger_id, invoice_id, datetime, amount, status, reference,
                                notes, allocateddate, batchnumber, source,
                                transaction_type)
-VALUES (NEXTVAL('ledger_allocation_id_seq'::REGCLASS), $1, $2, NOW(), $3, 'ALLOCATED', NULL, NULL, NULL, NULL, NULL,
+VALUES (NEXTVAL('supervision_finance.ledger_allocation_id_seq'::REGCLASS), $1, $2, NOW(), $3, 'ALLOCATED', NULL, NULL, NULL, NULL, NULL,
         NULL)
 RETURNING id, ledger_id, invoice_id, datetime, amount, status, reference, notes, allocateddate, batchnumber, source, transaction_type
 `
@@ -26,9 +26,9 @@ type CreateLedgerAllocationForFeeReductionParams struct {
 	Amount    int32
 }
 
-func (q *Queries) CreateLedgerAllocationForFeeReduction(ctx context.Context, arg CreateLedgerAllocationForFeeReductionParams) (LedgerAllocation, error) {
+func (q *Queries) CreateLedgerAllocationForFeeReduction(ctx context.Context, arg CreateLedgerAllocationForFeeReductionParams) (SupervisionFinanceLedgerAllocation, error) {
 	row := q.db.QueryRow(ctx, createLedgerAllocationForFeeReduction, arg.LedgerID, arg.InvoiceID, arg.Amount)
-	var i LedgerAllocation
+	var i SupervisionFinanceLedgerAllocation
 	err := row.Scan(
 		&i.ID,
 		&i.LedgerID,
@@ -47,9 +47,9 @@ func (q *Queries) CreateLedgerAllocationForFeeReduction(ctx context.Context, arg
 }
 
 const updateLedgerAllocationAdjustment = `-- name: UpdateLedgerAllocationAdjustment :exec
-UPDATE ledger_allocation la
+UPDATE supervision_finance.ledger_allocation la
 SET status = $1
-FROM ledger l
+FROM supervision_finance.ledger l
 WHERE l.id = $2
   AND l.id = la.ledger_id
   AND l.type IN ('CREDIT MEMO', 'CREDIT WRITE OFF', 'DEBIT MEMO')

--- a/finance-api/internal/store/models.go
+++ b/finance-api/internal/store/models.go
@@ -8,7 +8,22 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-type BillingPeriod struct {
+type Assignee struct {
+	ID          int32
+	Name        string
+	Type        string
+	Email       pgtype.Text
+	Surname     pgtype.Text
+	Roles       []byte
+	Suspended   pgtype.Bool
+	Phonenumber pgtype.Text
+	Deleted     pgtype.Timestamp
+	Teamtype    pgtype.Text
+	Updateddate pgtype.Timestamp
+	Permanent   pgtype.Bool
+}
+
+type SupervisionFinanceBillingPeriod struct {
 	ID              int32
 	FinanceClientID pgtype.Int4
 	OrderID         pgtype.Int4
@@ -16,13 +31,13 @@ type BillingPeriod struct {
 	EndDate         pgtype.Date
 }
 
-type Counter struct {
+type SupervisionFinanceCounter struct {
 	ID      int32
 	Key     string
 	Counter int32
 }
 
-type FeeReduction struct {
+type SupervisionFinanceFeeReduction struct {
 	ID              int32
 	FinanceClientID pgtype.Int4
 	// (DC2Type:refdata)
@@ -36,7 +51,7 @@ type FeeReduction struct {
 	Datereceived pgtype.Date
 }
 
-type FinanceClient struct {
+type SupervisionFinanceFinanceClient struct {
 	ID        int32
 	ClientID  int32
 	SopNumber string
@@ -45,7 +60,7 @@ type FinanceClient struct {
 	Batchnumber   pgtype.Int4
 }
 
-type Invoice struct {
+type SupervisionFinanceInvoice struct {
 	ID              int32
 	PersonID        pgtype.Int4
 	FinanceClientID pgtype.Int4
@@ -69,7 +84,7 @@ type Invoice struct {
 	FeeReductionID   pgtype.Int4
 }
 
-type InvoiceEmailStatus struct {
+type SupervisionFinanceInvoiceEmailStatus struct {
 	ID        int32
 	InvoiceID pgtype.Int4
 	// (DC2Type:refdata)
@@ -79,7 +94,7 @@ type InvoiceEmailStatus struct {
 	Createddate pgtype.Date
 }
 
-type InvoiceFeeRange struct {
+type SupervisionFinanceInvoiceFeeRange struct {
 	ID        int32
 	InvoiceID pgtype.Int4
 	// (DC2Type:refdata)
@@ -90,7 +105,7 @@ type InvoiceFeeRange struct {
 	Amount int32
 }
 
-type Ledger struct {
+type SupervisionFinanceLedger struct {
 	ID        int32
 	Reference string
 	Datetime  pgtype.Timestamp
@@ -116,7 +131,7 @@ type Ledger struct {
 	CreatedbyID pgtype.Int4
 }
 
-type LedgerAllocation struct {
+type SupervisionFinanceLedgerAllocation struct {
 	ID        int32
 	LedgerID  pgtype.Int4
 	InvoiceID pgtype.Int4
@@ -133,13 +148,13 @@ type LedgerAllocation struct {
 	TransactionType pgtype.Text
 }
 
-type Property struct {
+type SupervisionFinanceProperty struct {
 	ID    int32
 	Key   string
 	Value string
 }
 
-type Rate struct {
+type SupervisionFinanceRate struct {
 	ID        int32
 	Type      string
 	Startdate pgtype.Date
@@ -148,7 +163,7 @@ type Rate struct {
 	Amount int32
 }
 
-type Report struct {
+type SupervisionFinanceReport struct {
 	ID          int32
 	Batchnumber int32
 	// (DC2Type:refdata)

--- a/finance-api/internal/store/pending_invoice_adjustments.sql.go
+++ b/finance-api/internal/store/pending_invoice_adjustments.sql.go
@@ -12,20 +12,20 @@ import (
 )
 
 const getInvoiceAdjustments = `-- name: GetInvoiceAdjustments :many
-select l.id,
-       i.reference as invoice_ref,
-       l.datetime as raised_date,
+SELECT l.id,
+       i.reference AS invoice_ref,
+       l.datetime  AS raised_date,
        l.type,
        l.amount,
        l.notes,
        l.status
-from ledger l
-         inner join ledger_allocation lc on lc.ledger_id = l.id
-         inner join invoice i on i.id = lc.invoice_id
-         inner join finance_client fc on fc.id = i.finance_client_id
-where fc.client_id = $1
-and l.type IN ('CREDIT MEMO', 'CREDIT WRITE OFF', 'DEBIT MEMO')
-order by l.datetime desc
+FROM supervision_finance.ledger l
+         INNER JOIN supervision_finance.ledger_allocation lc ON lc.ledger_id = l.id
+         INNER JOIN supervision_finance.invoice i ON i.id = lc.invoice_id
+         INNER JOIN supervision_finance.finance_client fc ON fc.id = i.finance_client_id
+WHERE fc.client_id = $1
+  AND l.type IN ('CREDIT MEMO', 'CREDIT WRITE OFF', 'DEBIT MEMO')
+ORDER BY l.datetime DESC
 `
 
 type GetInvoiceAdjustmentsRow struct {

--- a/finance-api/internal/store/queries/fee_reductions.sql
+++ b/finance-api/internal/store/queries/fee_reductions.sql
@@ -1,5 +1,5 @@
 -- name: GetFeeReductions :many
-select fr.id,
+SELECT fr.id,
        finance_client_id,
        type,
        startdate,
@@ -7,27 +7,34 @@ select fr.id,
        datereceived,
        notes,
        deleted
-from fee_reduction fr
-         inner join finance_client fc on fc.id = fr.finance_client_id
-where fc.client_id = $1
-order by enddate desc, deleted;
+FROM supervision_finance.fee_reduction fr
+         INNER JOIN supervision_finance.finance_client fc ON fc.id = fr.finance_client_id
+WHERE fc.client_id = $1
+ORDER BY enddate DESC, deleted;
 
 -- name: AddFeeReduction :one
-insert into fee_reduction (id,
-                           finance_client_id,
-                           type,
-                           startdate,
-                           enddate,
-                           notes,
-                           deleted,
-                           datereceived) values (nextval('fee_reduction_id_seq'::regclass), (select id from finance_client where client_id = $1), $2, $3, $4, $5, $6, $7) returning *;
+INSERT INTO supervision_finance.fee_reduction (id,
+                                               finance_client_id,
+                                               type,
+                                               startdate,
+                                               enddate,
+                                               notes,
+                                               deleted,
+                                               datereceived)
+VALUES (NEXTVAL('supervision_finance.fee_reduction_id_seq'::REGCLASS),
+        (SELECT id FROM supervision_finance.finance_client WHERE client_id = $1), $2, $3, $4, $5, $6, $7)
+RETURNING *;
 
 -- name: CountOverlappingFeeReduction :one
 SELECT COUNT(*)
-from fee_reduction fr
-         inner join finance_client fc on fc.id = fr.finance_client_id
-where fc.client_id = $1 and fr.deleted = false
-  and (fr.startdate, fr.enddate) OVERLAPS ($2, $3);
+FROM supervision_finance.fee_reduction fr
+         INNER JOIN supervision_finance.finance_client fc ON fc.id = fr.finance_client_id
+WHERE fc.client_id = $1
+  AND fr.deleted = FALSE
+  AND (fr.startdate, fr.enddate) OVERLAPS ($2, $3);
 
 -- name: CancelFeeReduction :one
-update fee_reduction set deleted = true where id = $1 returning *;
+UPDATE supervision_finance.fee_reduction
+SET deleted = TRUE
+WHERE id = $1
+RETURNING *;

--- a/finance-api/internal/store/queries/finance_client.sql
+++ b/finance-api/internal/store/queries/finance_client.sql
@@ -1,12 +1,13 @@
 -- name: GetAccountInformation :one
 WITH balances AS (SELECT i.id, fc.client_id, i.amount, COALESCE(SUM(la.amount), 0) paid
-FROM finance_client fc
-         LEFT JOIN invoice i ON fc.id = i.finance_client_id
-         LEFT JOIN ledger_allocation la ON i.id = la.invoice_id AND la.status IN ('ALLOCATED', 'APPROVED')
-WHERE fc.client_id = $1
-GROUP BY i.id, fc.client_id)
+                  FROM supervision_finance.finance_client fc
+                           LEFT JOIN supervision_finance.invoice i ON fc.id = i.finance_client_id
+                           LEFT JOIN supervision_finance.ledger_allocation la
+                                     ON i.id = la.invoice_id AND la.status IN ('ALLOCATED', 'APPROVED')
+                  WHERE fc.client_id = $1
+                  GROUP BY i.id, fc.client_id)
 SELECT COALESCE(SUM(balances.amount), 0) - SUM(balances.paid) outstanding, 0 credit, fc.payment_method
-FROM finance_client fc
-JOIN balances ON fc.client_id = balances.client_id
+FROM supervision_finance.finance_client fc
+         JOIN balances ON fc.client_id = balances.client_id
 WHERE fc.client_id = $1
 GROUP BY fc.payment_method;

--- a/finance-api/internal/store/queries/invoice_fee_range.sql
+++ b/finance-api/internal/store/queries/invoice_fee_range.sql
@@ -1,6 +1,5 @@
-SET SEARCH_PATH TO supervision_finance;
-
 -- name: GetInvoiceFeeRangeAmount :one
-select sum(amount) / 2
-from invoice_fee_range
-where invoice_id = $1 and supervisionlevel = $2;
+SELECT SUM(amount) / 2
+FROM supervision_finance.invoice_fee_range
+WHERE invoice_id = $1
+  AND supervisionlevel = $2;

--- a/finance-api/internal/store/queries/invoices.sql
+++ b/finance-api/internal/store/queries/invoices.sql
@@ -1,47 +1,44 @@
-SET SEARCH_PATH TO supervision_finance;
-
 -- name: GetInvoices :many
-SELECT i.id, i.reference, i.amount, i.raiseddate, COALESCE(SUM(la.amount), 0)::int received
-FROM invoice i
-         JOIN finance_client fc ON fc.id = i.finance_client_id
-         LEFT JOIN ledger_allocation la ON i.id = la.invoice_id AND la.status IN ('ALLOCATED', 'APPROVED')
+SELECT i.id, i.reference, i.amount, i.raiseddate, COALESCE(SUM(la.amount), 0)::INT received
+FROM supervision_finance.invoice i
+         JOIN supervision_finance.finance_client fc ON fc.id = i.finance_client_id
+         LEFT JOIN supervision_finance.ledger_allocation la
+                   ON i.id = la.invoice_id AND la.status IN ('ALLOCATED', 'APPROVED')
 WHERE fc.client_id = $1
 GROUP BY i.id, i.raiseddate
 ORDER BY i.raiseddate DESC;
 
 -- name: GetInvoiceBalance :one
 SELECT i.amount initial, i.amount - COALESCE(SUM(la.amount), 0) outstanding, i.feetype
-FROM invoice i
-         LEFT JOIN ledger_allocation la on i.id = la.invoice_id
+FROM supervision_finance.invoice i
+         LEFT JOIN supervision_finance.ledger_allocation la on i.id = la.invoice_id
     AND la.status IN ('ALLOCATED', 'APPROVED')
 WHERE i.id = $1
-group by i.amount, i.feetype;
+GROUP BY i.amount, i.feetype;
 
 -- name: GetLedgerAllocations :many
-select la.id, la.amount, la.datetime, l.bankdate, l.type, la.status
-from ledger_allocation la
-         inner join ledger l on la.ledger_id = l.id
-where la.invoice_id = $1
-order by la.id desc;
+SELECT la.id, la.amount, la.datetime, l.bankdate, l.type, la.status
+FROM supervision_finance.ledger_allocation la
+         INNER JOIN supervision_finance.ledger l ON la.ledger_id = l.id
+WHERE la.invoice_id = $1
+ORDER BY la.id DESC;
 
 -- name: GetSupervisionLevels :many
-select supervisionlevel, fromdate, todate, amount
-from invoice_fee_range
-where invoice_id = $1
-order by todate desc;
+SELECT supervisionlevel, fromdate, todate, amount
+FROM supervision_finance.invoice_fee_range
+WHERE invoice_id = $1
+ORDER BY todate DESC;
 
 -- name: AddFeeReductionToInvoices :many
-WITH filtered_invoices AS (
-    SELECT i.id AS invoice_id, fr.id AS fee_reduction_id
-    FROM invoice i
-             JOIN fee_reduction fr
-                  ON i.finance_client_id = fr.finance_client_id
-    WHERE i.raiseddate >= (fr.datereceived - interval '6 months')
-      AND i.raiseddate BETWEEN fr.startdate AND fr.enddate
-      AND fr.id = $1
-)
-UPDATE invoice i
+WITH filtered_invoices AS (SELECT i.id AS invoice_id, fr.id AS fee_reduction_id
+                           FROM supervision_finance.invoice i
+                                    JOIN supervision_finance.fee_reduction fr
+                                         ON i.finance_client_id = fr.finance_client_id
+                           WHERE i.raiseddate >= (fr.datereceived - INTERVAL '6 months')
+                             AND i.raiseddate BETWEEN fr.startdate AND fr.enddate
+                             AND fr.id = $1)
+UPDATE supervision_finance.invoice i
 SET fee_reduction_id = fi.fee_reduction_id
 FROM filtered_invoices fi
 WHERE i.id = fi.invoice_id
-returning i.*;
+RETURNING i.*;

--- a/finance-api/internal/store/queries/ledger.sql
+++ b/finance-api/internal/store/queries/ledger.sql
@@ -1,22 +1,25 @@
 -- name: CreateLedgerForFeeReduction :one
-insert into ledger (id, reference, datetime, method, amount, notes, type, status, finance_client_id,
-                    parent_id, fee_reduction_id, confirmeddate, bankdate, batchnumber, bankaccount,
-                    line, source,
-                    createddate, createdby_id)
-VALUES (nextval('ledger_id_seq'::regclass), gen_random_uuid(), now(), $1, $2, $3, $4, 'Status', $5, null, $6, null,
-        null, null, null, null, null, now(), $7) returning *;
+INSERT INTO supervision_finance.ledger (id, reference, datetime, method, amount, notes, type, status, finance_client_id,
+                                        parent_id, fee_reduction_id, confirmeddate, bankdate, batchnumber, bankaccount,
+                                        line, source,
+                                        createddate, createdby_id)
+VALUES (NEXTVAL('supervision_finance.ledger_id_seq'::REGCLASS), gen_random_uuid(), NOW(), $1, $2, $3, $4, 'Status', $5,
+        NULL, $6, NULL,
+        NULL, NULL, NULL, NULL, NULL, NOW(), $7)
+RETURNING *;
 
 -- name: UpdateLedgerAdjustment :exec
-UPDATE ledger l
+UPDATE supervision_finance.ledger l
 SET status = $1
 WHERE l.id = $2;
 
 -- name: CreateLedger :one
-WITH fc AS (SELECT id FROM finance_client WHERE client_id = $1),
+WITH fc AS (SELECT id FROM supervision_finance.finance_client WHERE client_id = $1),
      ledger AS (
-         INSERT INTO ledger (id, datetime, amount, notes, type, finance_client_id, reference, method, status)
-             SELECT nextval('ledger_id_seq'),
-                    now(),
+         INSERT INTO supervision_finance.ledger (id, datetime, amount, notes, type, finance_client_id, reference,
+                                                 method, status)
+             SELECT NEXTVAL('supervision_finance.ledger_id_seq'),
+                    NOW(),
                     $3,
                     $4,
                     $5,
@@ -27,8 +30,8 @@ WITH fc AS (SELECT id FROM finance_client WHERE client_id = $1),
              FROM fc
              RETURNING id, datetime)
 INSERT
-INTO ledger_allocation (id, ledger_id, invoice_id, datetime, amount, status, notes)
-SELECT nextval('ledger_allocation_id_seq'),
+INTO supervision_finance.ledger_allocation (id, ledger_id, invoice_id, datetime, amount, status, notes)
+SELECT NEXTVAL('supervision_finance.ledger_allocation_id_seq'),
        ledger.id,
        $2,
        ledger.datetime,
@@ -36,4 +39,4 @@ SELECT nextval('ledger_allocation_id_seq'),
        'PENDING',
        $4
 FROM ledger
-returning (SELECT reference invoiceReference FROM invoice WHERE id = invoice_id);
+RETURNING (SELECT reference invoicereference FROM supervision_finance.invoice WHERE id = invoice_id);

--- a/finance-api/internal/store/queries/ledger_allocation.sql
+++ b/finance-api/internal/store/queries/ledger_allocation.sql
@@ -1,15 +1,15 @@
 -- name: CreateLedgerAllocationForFeeReduction :one
-INSERT INTO ledger_allocation (id, ledger_id, invoice_id, datetime, amount, status, reference,
+INSERT INTO supervision_finance.ledger_allocation (id, ledger_id, invoice_id, datetime, amount, status, reference,
                                notes, allocateddate, batchnumber, source,
                                transaction_type)
-VALUES (NEXTVAL('ledger_allocation_id_seq'::REGCLASS), $1, $2, NOW(), $3, 'ALLOCATED', NULL, NULL, NULL, NULL, NULL,
+VALUES (NEXTVAL('supervision_finance.ledger_allocation_id_seq'::REGCLASS), $1, $2, NOW(), $3, 'ALLOCATED', NULL, NULL, NULL, NULL, NULL,
         NULL)
 RETURNING *;
 
 -- name: UpdateLedgerAllocationAdjustment :exec
-UPDATE ledger_allocation la
+UPDATE supervision_finance.ledger_allocation la
 SET status = $1
-FROM ledger l
+FROM supervision_finance.ledger l
 WHERE l.id = $2
   AND l.id = la.ledger_id
   AND l.type IN ('CREDIT MEMO', 'CREDIT WRITE OFF', 'DEBIT MEMO');

--- a/finance-api/internal/store/queries/pending_invoice_adjustments.sql
+++ b/finance-api/internal/store/queries/pending_invoice_adjustments.sql
@@ -1,15 +1,15 @@
 -- name: GetInvoiceAdjustments :many
-select l.id,
-       i.reference as invoice_ref,
-       l.datetime as raised_date,
+SELECT l.id,
+       i.reference AS invoice_ref,
+       l.datetime  AS raised_date,
        l.type,
        l.amount,
        l.notes,
        l.status
-from ledger l
-         inner join ledger_allocation lc on lc.ledger_id = l.id
-         inner join invoice i on i.id = lc.invoice_id
-         inner join finance_client fc on fc.id = i.finance_client_id
-where fc.client_id = $1
-and l.type IN ('CREDIT MEMO', 'CREDIT WRITE OFF', 'DEBIT MEMO')
-order by l.datetime desc;
+FROM supervision_finance.ledger l
+         INNER JOIN supervision_finance.ledger_allocation lc ON lc.ledger_id = l.id
+         INNER JOIN supervision_finance.invoice i ON i.id = lc.invoice_id
+         INNER JOIN supervision_finance.finance_client fc ON fc.id = i.finance_client_id
+WHERE fc.client_id = $1
+  AND l.type IN ('CREDIT MEMO', 'CREDIT WRITE OFF', 'DEBIT MEMO')
+ORDER BY l.datetime DESC;

--- a/finance-api/internal/testhelpers/test_db.go
+++ b/finance-api/internal/testhelpers/test_db.go
@@ -64,7 +64,7 @@ func InitDb() *TestDatabase {
 		log.Fatal(err)
 	}
 
-	connString, err := container.ConnectionString(ctx, "search_path=supervision_finance")
+	connString, err := container.ConnectionString(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/finance-api/main.go
+++ b/finance-api/main.go
@@ -76,7 +76,7 @@ func main() {
 	// Open a connection to the PostgreSQL database
 	ctx := context.Background()
 
-	conn, err := pgx.Connect(ctx, fmt.Sprintf("postgresql://%s:%s@%s/%s?search_path=supervision_finance", dbUser, dbPassword, dbConn, pgDb))
+	conn, err := pgx.Connect(ctx, fmt.Sprintf("postgresql://%s:%s@%s/%s", dbUser, dbPassword, dbConn, pgDb))
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/migrations/1_baseline.sql
+++ b/migrations/1_baseline.sql
@@ -1,378 +1,398 @@
 -- +goose Up
 CREATE ROLE api;
+
+CREATE TABLE public.assignees
+(
+    id          INTEGER      NOT NULL
+        PRIMARY KEY,
+    name        VARCHAR(255) NOT NULL,
+    type        VARCHAR(255) NOT NULL,
+    email       VARCHAR(255) DEFAULT NULL::CHARACTER VARYING,
+    surname     VARCHAR(255) DEFAULT NULL::CHARACTER VARYING,
+    roles       JSON,
+    suspended   BOOLEAN      DEFAULT FALSE,
+    phonenumber VARCHAR(255) DEFAULT NULL::CHARACTER VARYING,
+    deleted     TIMESTAMP(0),
+    teamtype    VARCHAR(255) DEFAULT NULL::CHARACTER VARYING,
+    updateddate TIMESTAMP(0) DEFAULT NULL::TIMESTAMP WITHOUT TIME ZONE,
+    permanent   BOOLEAN      DEFAULT FALSE
+);
+
+ALTER TABLE public.assignees
+    OWNER TO api;
+
 CREATE SCHEMA supervision_finance;
 GRANT ALL ON SCHEMA supervision_finance TO api;
-SET SEARCH_PATH TO supervision_finance;
 
-create sequence billing_period_id_seq;
+CREATE SEQUENCE supervision_finance.billing_period_id_seq;
 
-alter sequence billing_period_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.billing_period_id_seq OWNER TO api;
 
-create sequence counter_id_seq;
+CREATE SEQUENCE supervision_finance.counter_id_seq;
 
-alter sequence counter_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.counter_id_seq OWNER TO api;
 
-create sequence fee_reduction_id_seq;
+CREATE SEQUENCE supervision_finance.fee_reduction_id_seq;
 
-alter sequence fee_reduction_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.fee_reduction_id_seq OWNER TO api;
 
-create sequence finance_client_id_seq;
+CREATE SEQUENCE supervision_finance.finance_client_id_seq;
 
-alter sequence finance_client_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.finance_client_id_seq OWNER TO api;
 
-create sequence invoice_email_status_id_seq;
+CREATE SEQUENCE supervision_finance.invoice_email_status_id_seq;
 
-alter sequence invoice_email_status_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.invoice_email_status_id_seq OWNER TO api;
 
-create sequence invoice_fee_range_id_seq;
+CREATE SEQUENCE supervision_finance.invoice_fee_range_id_seq;
 
-alter sequence invoice_fee_range_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.invoice_fee_range_id_seq OWNER TO api;
 
-create sequence invoice_id_seq;
+CREATE SEQUENCE supervision_finance.invoice_id_seq;
 
-alter sequence invoice_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.invoice_id_seq OWNER TO api;
 
-create sequence ledger_allocation_id_seq;
+CREATE SEQUENCE supervision_finance.ledger_allocation_id_seq;
 
-alter sequence ledger_allocation_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.ledger_allocation_id_seq OWNER TO api;
 
-create sequence ledger_id_seq;
+CREATE SEQUENCE supervision_finance.ledger_id_seq;
 
-alter sequence ledger_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.ledger_id_seq OWNER TO api;
 
-create sequence property_id_seq;
+CREATE SEQUENCE supervision_finance.property_id_seq;
 
-alter sequence property_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.property_id_seq OWNER TO api;
 
-create sequence rate_id_seq;
+CREATE SEQUENCE supervision_finance.rate_id_seq;
 
-alter sequence rate_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.rate_id_seq OWNER TO api;
 
-create sequence report_id_seq;
+CREATE SEQUENCE supervision_finance.report_id_seq;
 
-alter sequence report_id_seq owner to api;
+ALTER SEQUENCE supervision_finance.report_id_seq OWNER TO api;
 
-create table counter
+CREATE TABLE supervision_finance.counter
 (
-    id      integer     not null
-        primary key,
-    key     varchar(50) not null,
-    counter integer     not null
+    id      INTEGER     NOT NULL
+        PRIMARY KEY,
+    key     VARCHAR(50) NOT NULL,
+    counter INTEGER     NOT NULL
 );
 
-alter table counter
-    owner to api;
+ALTER TABLE supervision_finance.counter
+    OWNER TO api;
 
-create index idx_counter_key
-    on counter (key);
+CREATE INDEX idx_counter_key
+    ON supervision_finance.counter (key);
 
-create unique index uniq_26df0c148a90aba9
-    on counter (key);
+CREATE UNIQUE INDEX uniq_26df0c148a90aba9
+    ON supervision_finance.counter (key);
 
-create table finance_client
+CREATE TABLE supervision_finance.finance_client
 (
-    id             integer      not null
-        primary key,
-    client_id      integer      not null,
-    sop_number     text         not null,
-    payment_method varchar(255) not null,
-    batchnumber    integer
+    id             INTEGER      NOT NULL
+        PRIMARY KEY,
+    client_id      INTEGER      NOT NULL,
+    sop_number     TEXT         NOT NULL,
+    payment_method VARCHAR(255) NOT NULL,
+    batchnumber    INTEGER
 );
 
-comment on column finance_client.payment_method is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.finance_client.payment_method IS '(DC2Type:refdata)';
 
-alter table finance_client
-    owner to api;
+ALTER TABLE supervision_finance.finance_client
+    OWNER TO api;
 
-create table billing_period
+CREATE TABLE supervision_finance.billing_period
 (
-    id                integer not null
-        primary key,
-    finance_client_id integer
-        constraint fk_f586876342ac816b
-            references finance_client,
-    order_id          integer,
-    start_date        date    not null,
-    end_date          date
+    id                INTEGER NOT NULL
+        PRIMARY KEY,
+    finance_client_id INTEGER
+        CONSTRAINT fk_f586876342ac816b
+            REFERENCES supervision_finance.finance_client,
+    order_id          INTEGER,
+    start_date        DATE    NOT NULL,
+    end_date          DATE
 );
 
-alter table billing_period
-    owner to api;
+ALTER TABLE supervision_finance.billing_period
+    OWNER TO api;
 
-create index idx_c64d624c7a3c530d
-    on billing_period (finance_client_id);
+CREATE INDEX idx_c64d624c7a3c530d
+    ON supervision_finance.billing_period (finance_client_id);
 
-create table fee_reduction
+CREATE TABLE supervision_finance.fee_reduction
 (
-    id                integer                    not null
-        primary key,
-    finance_client_id integer
-        constraint fk_6ab78de42ac816b
-            references finance_client,
-    type              varchar(255)               not null,
-    evidencetype      varchar(255) default NULL::character varying,
-    startdate         date                       not null,
-    enddate           date                       not null,
-    notes             text                       not null,
-    deleted           boolean      default false not null,
-    datereceived      date
+    id                INTEGER                    NOT NULL
+        PRIMARY KEY,
+    finance_client_id INTEGER
+        CONSTRAINT fk_6ab78de42ac816b
+            REFERENCES supervision_finance.finance_client,
+    type              VARCHAR(255)               NOT NULL,
+    evidencetype      VARCHAR(255) DEFAULT NULL::CHARACTER VARYING,
+    startdate         DATE                       NOT NULL,
+    enddate           DATE                       NOT NULL,
+    notes             TEXT                       NOT NULL,
+    deleted           BOOLEAN      DEFAULT FALSE NOT NULL,
+    datereceived      DATE
 );
 
-comment on column fee_reduction.type is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.fee_reduction.type IS '(DC2Type:refdata)';
 
-comment on column fee_reduction.evidencetype is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.fee_reduction.evidencetype IS '(DC2Type:refdata)';
 
-alter table fee_reduction
-    owner to api;
+ALTER TABLE supervision_finance.fee_reduction
+    OWNER TO api;
 
-create index idx_690054cf7a3c530d
-    on fee_reduction (finance_client_id);
+CREATE INDEX idx_690054cf7a3c530d
+    ON supervision_finance.fee_reduction (finance_client_id);
 
-create index idx_finance_client_batch_number
-    on finance_client (batchnumber);
+CREATE INDEX idx_finance_client_batch_number
+    ON supervision_finance.finance_client (batchnumber);
 
-create table invoice
+CREATE TABLE supervision_finance.invoice
 (
-    id                integer     not null
-        primary key,
-    person_id         integer,
-    finance_client_id integer
-        constraint fk_7df7fbe042ac816b
-            references finance_client
-            on delete cascade,
-    feetype           text        not null,
-    reference         varchar(50) not null,
-    startdate         date        not null,
-    enddate           date        not null,
-    amount            integer     not null,
-    supervisionlevel  varchar(255) default NULL::character varying,
-    confirmeddate     date,
-    batchnumber       integer,
-    raiseddate        date,
-    source            varchar(20)  default NULL::character varying,
-    scheduledfn14date date,
-    cacheddebtamount  integer
+    id                INTEGER     NOT NULL
+        PRIMARY KEY,
+    person_id         INTEGER,
+    finance_client_id INTEGER
+        CONSTRAINT fk_7df7fbe042ac816b
+            REFERENCES supervision_finance.finance_client
+            ON DELETE CASCADE,
+    feetype           TEXT        NOT NULL,
+    reference         VARCHAR(50) NOT NULL,
+    startdate         DATE        NOT NULL,
+    enddate           DATE        NOT NULL,
+    amount            INTEGER     NOT NULL,
+    supervisionlevel  VARCHAR(255) DEFAULT NULL::CHARACTER VARYING,
+    confirmeddate     DATE,
+    batchnumber       INTEGER,
+    raiseddate        DATE,
+    source            VARCHAR(20)  DEFAULT NULL::CHARACTER VARYING,
+    scheduledfn14date DATE,
+    cacheddebtamount  INTEGER
 );
 
-comment on column invoice.amount is '(DC2Type:money)';
+COMMENT ON COLUMN supervision_finance.invoice.amount IS '(DC2Type:money)';
 
-comment on column invoice.supervisionlevel is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.invoice.supervisionlevel IS '(DC2Type:refdata)';
 
-comment on column invoice.cacheddebtamount is '(DC2Type:money)';
+COMMENT ON COLUMN supervision_finance.invoice.cacheddebtamount IS '(DC2Type:money)';
 
-alter table invoice
-    owner to api;
+ALTER TABLE supervision_finance.invoice
+    OWNER TO api;
 
-create index idx_77988f287a3c530d
-    on invoice (finance_client_id);
+CREATE INDEX idx_77988f287a3c530d
+    ON supervision_finance.invoice (finance_client_id);
 
-create index idx_invoice_batch_number
-    on invoice (batchnumber);
+CREATE INDEX idx_invoice_batch_number
+    ON supervision_finance.invoice (batchnumber);
 
-create unique index uniq_77988f28aea34913
-    on invoice (reference);
+CREATE UNIQUE INDEX uniq_77988f28aea34913
+    ON supervision_finance.invoice (reference);
 
-create table invoice_email_status
+CREATE TABLE supervision_finance.invoice_email_status
 (
-    id          integer      not null
-        primary key,
-    invoice_id  integer
-        constraint fk_64081dd12989f1fd
-            references invoice
-            on delete cascade,
-    status      varchar(255) not null,
-    templateid  varchar(255) not null,
-    createddate date
+    id          INTEGER      NOT NULL
+        PRIMARY KEY,
+    invoice_id  INTEGER
+        CONSTRAINT fk_64081dd12989f1fd
+            REFERENCES supervision_finance.invoice
+            ON DELETE CASCADE,
+    status      VARCHAR(255) NOT NULL,
+    templateid  VARCHAR(255) NOT NULL,
+    createddate DATE
 );
 
-comment on column invoice_email_status.status is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.invoice_email_status.status IS '(DC2Type:refdata)';
 
-comment on column invoice_email_status.templateid is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.invoice_email_status.templateid IS '(DC2Type:refdata)';
 
-alter table invoice_email_status
-    owner to api;
+ALTER TABLE supervision_finance.invoice_email_status
+    OWNER TO api;
 
-create index idx_d0ae32bc2989f1fd
-    on invoice_email_status (invoice_id);
+CREATE INDEX idx_d0ae32bc2989f1fd
+    ON supervision_finance.invoice_email_status (invoice_id);
 
-create table invoice_fee_range
+CREATE TABLE supervision_finance.invoice_fee_range
 (
-    id               integer      not null
-        primary key,
-    invoice_id       integer
-        constraint fk_36446bf82989f1fd
-            references invoice
-            on delete cascade,
-    supervisionlevel varchar(255) not null,
-    fromdate         date         not null,
-    todate           date         not null,
-    amount           integer      not null
+    id               INTEGER      NOT NULL
+        PRIMARY KEY,
+    invoice_id       INTEGER
+        CONSTRAINT fk_36446bf82989f1fd
+            REFERENCES supervision_finance.invoice
+            ON DELETE CASCADE,
+    supervisionlevel VARCHAR(255) NOT NULL,
+    fromdate         DATE         NOT NULL,
+    todate           DATE         NOT NULL,
+    amount           INTEGER      NOT NULL
 );
 
-comment on column invoice_fee_range.supervisionlevel is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.invoice_fee_range.supervisionlevel IS '(DC2Type:refdata)';
 
-comment on column invoice_fee_range.amount is '(DC2Type:money)';
+COMMENT ON COLUMN supervision_finance.invoice_fee_range.amount IS '(DC2Type:money)';
 
-alter table invoice_fee_range
-    owner to api;
+ALTER TABLE supervision_finance.invoice_fee_range
+    OWNER TO api;
 
-create index idx_5dd85a2d2989f1fd
-    on invoice_fee_range (invoice_id);
+CREATE INDEX idx_5dd85a2d2989f1fd
+    ON supervision_finance.invoice_fee_range (invoice_id);
 
-create table ledger
+CREATE TABLE supervision_finance.ledger
 (
-    id                integer                                      not null
-        primary key,
-    reference         varchar(50)                                  not null,
-    datetime          timestamp(0)                                 not null,
-    method            varchar(255)                                 not null,
-    amount            integer                                      not null,
-    notes             text,
-    type              varchar(255)                                 not null,
-    status            varchar(255) default NULL::character varying not null,
-    finance_client_id integer
-        constraint fk_ea14203c42ac816b
-            references finance_client
-            on delete cascade,
-    parent_id         integer
-        constraint fk_ea14203c727aca70
-            references ledger
-            on delete cascade,
-    fee_reduction_id  integer
-        constraint fk_ea14203c47b45492
-            references fee_reduction
-            on delete cascade,
-    confirmeddate     date,
-    bankdate          date,
-    batchnumber       integer,
-    bankaccount       varchar(255) default NULL::character varying,
-    source            varchar(20)  default NULL::character varying,
-    line              integer
+    id                INTEGER                                      NOT NULL
+        PRIMARY KEY,
+    reference         VARCHAR(50)                                  NOT NULL,
+    datetime          TIMESTAMP(0)                                 NOT NULL,
+    method            VARCHAR(255)                                 NOT NULL,
+    amount            INTEGER                                      NOT NULL,
+    notes             TEXT,
+    type              VARCHAR(255)                                 NOT NULL,
+    status            VARCHAR(255) DEFAULT NULL::CHARACTER VARYING NOT NULL,
+    finance_client_id INTEGER
+        CONSTRAINT fk_ea14203c42ac816b
+            REFERENCES supervision_finance.finance_client
+            ON DELETE CASCADE,
+    parent_id         INTEGER
+        CONSTRAINT fk_ea14203c727aca70
+            REFERENCES supervision_finance.ledger
+            ON DELETE CASCADE,
+    fee_reduction_id  INTEGER
+        CONSTRAINT fk_ea14203c47b45492
+            REFERENCES supervision_finance.fee_reduction
+            ON DELETE CASCADE,
+    confirmeddate     DATE,
+    bankdate          DATE,
+    batchnumber       INTEGER,
+    bankaccount       VARCHAR(255) DEFAULT NULL::CHARACTER VARYING,
+    source            VARCHAR(20)  DEFAULT NULL::CHARACTER VARYING,
+    line              INTEGER
 );
 
-comment on column ledger.amount is '(DC2Type:money)';
+COMMENT ON COLUMN supervision_finance.ledger.amount IS '(DC2Type:money)';
 
-comment on column ledger.type is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.ledger.type IS '(DC2Type:refdata)';
 
-comment on column ledger.status is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.ledger.status IS '(DC2Type:refdata)';
 
-comment on column ledger.bankaccount is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.ledger.bankaccount IS '(DC2Type:refdata)';
 
-alter table ledger
-    owner to api;
+ALTER TABLE supervision_finance.ledger
+    OWNER TO api;
 
-create index idx_85cecfb26abf21a3
-    on ledger (fee_reduction_id);
+CREATE INDEX idx_85cecfb26abf21a3
+    ON supervision_finance.ledger (fee_reduction_id);
 
-create index idx_85cecfb2727aca70
-    on ledger (parent_id);
+CREATE INDEX idx_85cecfb2727aca70
+    ON supervision_finance.ledger (parent_id);
 
-create index idx_85cecfb27a3c530d
-    on ledger (finance_client_id);
+CREATE INDEX idx_85cecfb27a3c530d
+    ON supervision_finance.ledger (finance_client_id);
 
-create index idx_ledger_batch_number
-    on ledger (batchnumber);
+CREATE INDEX idx_ledger_batch_number
+    ON supervision_finance.ledger (batchnumber);
 
-create unique index uniq_85cecfb2aea34913
-    on ledger (reference);
+CREATE UNIQUE INDEX uniq_85cecfb2aea34913
+    ON supervision_finance.ledger (reference);
 
-create table ledger_allocation
+CREATE TABLE supervision_finance.ledger_allocation
 (
-    id            integer      not null
-        primary key,
-    ledger_id     integer
-        constraint fk_b11e238deb264cb8
-            references ledger
-            on delete cascade,
-    invoice_id    integer
-        constraint fk_b11e238d2989f1fd
-            references invoice
-            on delete cascade,
-    datetime      timestamp(0) not null,
-    amount        integer      not null,
-    status        varchar(255) not null,
-    reference     varchar(25) default NULL::character varying,
-    notes         text,
-    allocateddate date,
-    batchnumber   integer,
-    source        varchar(20) default NULL::character varying
+    id            INTEGER      NOT NULL
+        PRIMARY KEY,
+    ledger_id     INTEGER
+        CONSTRAINT fk_b11e238deb264cb8
+            REFERENCES supervision_finance.ledger
+            ON DELETE CASCADE,
+    invoice_id    INTEGER
+        CONSTRAINT fk_b11e238d2989f1fd
+            REFERENCES supervision_finance.invoice
+            ON DELETE CASCADE,
+    datetime      TIMESTAMP(0) NOT NULL,
+    amount        INTEGER      NOT NULL,
+    status        VARCHAR(255) NOT NULL,
+    reference     VARCHAR(25) DEFAULT NULL::CHARACTER VARYING,
+    notes         TEXT,
+    allocateddate DATE,
+    batchnumber   INTEGER,
+    source        VARCHAR(20) DEFAULT NULL::CHARACTER VARYING
 );
 
-comment on column ledger_allocation.amount is '(DC2Type:money)';
+COMMENT ON COLUMN supervision_finance.ledger_allocation.amount IS '(DC2Type:money)';
 
-comment on column ledger_allocation.status is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.ledger_allocation.status IS '(DC2Type:refdata)';
 
-alter table ledger_allocation
-    owner to api;
+ALTER TABLE supervision_finance.ledger_allocation
+    OWNER TO api;
 
-create index idx_da8212582989f1fd
-    on ledger_allocation (invoice_id);
+CREATE INDEX idx_da8212582989f1fd
+    ON supervision_finance.ledger_allocation (invoice_id);
 
-create index idx_da821258a7b913dd
-    on ledger_allocation (ledger_id);
+CREATE INDEX idx_da821258a7b913dd
+    ON supervision_finance.ledger_allocation (ledger_id);
 
-create index idx_ledger_allocation_batch_number
-    on ledger_allocation (batchnumber);
+CREATE INDEX idx_ledger_allocation_batch_number
+    ON supervision_finance.ledger_allocation (batchnumber);
 
-create unique index uniq_da821258aea34913
-    on ledger_allocation (reference);
+CREATE UNIQUE INDEX uniq_da821258aea34913
+    ON supervision_finance.ledger_allocation (reference);
 
-create table property
+CREATE TABLE supervision_finance.property
 (
-    id    integer      not null
-        primary key,
-    key   varchar(100) not null,
-    value varchar(255) not null
+    id    INTEGER      NOT NULL
+        PRIMARY KEY,
+    key   VARCHAR(100) NOT NULL,
+    value VARCHAR(255) NOT NULL
 );
 
-alter table property
-    owner to api;
+ALTER TABLE supervision_finance.property
+    OWNER TO api;
 
-create unique index uniq_cf11cc358a90aba9
-    on property (key);
+CREATE UNIQUE INDEX uniq_cf11cc358a90aba9
+    ON supervision_finance.property (key);
 
-create table rate
+CREATE TABLE supervision_finance.rate
 (
-    id        integer     not null
-        primary key,
-    type      varchar(50) not null,
-    startdate date,
-    enddate   date,
-    amount    integer     not null
+    id        INTEGER     NOT NULL
+        PRIMARY KEY,
+    type      VARCHAR(50) NOT NULL,
+    startdate DATE,
+    enddate   DATE,
+    amount    INTEGER     NOT NULL
 );
 
-comment on column rate.amount is '(DC2Type:money)';
+COMMENT ON COLUMN supervision_finance.rate.amount IS '(DC2Type:money)';
 
-alter table rate
-    owner to api;
+ALTER TABLE supervision_finance.rate
+    OWNER TO api;
 
-create table report
+CREATE TABLE supervision_finance.report
 (
-    id                    integer      not null
-        primary key,
-    batchnumber           integer      not null,
-    type                  varchar(255) not null,
-    datetime              timestamp(0) not null,
-    count                 integer      not null,
-    invoicedate           timestamp(0),
-    totalamount           integer,
-    firstinvoicereference varchar(50) default NULL::character varying,
-    lastinvoicereference  varchar(50) default NULL::character varying,
-    createdbyuser_id      integer
+    id                    INTEGER      NOT NULL
+        PRIMARY KEY,
+    batchnumber           INTEGER      NOT NULL,
+    type                  VARCHAR(255) NOT NULL,
+    datetime              TIMESTAMP(0) NOT NULL,
+    count                 INTEGER      NOT NULL,
+    invoicedate           TIMESTAMP(0),
+    totalamount           INTEGER,
+    firstinvoicereference VARCHAR(50) DEFAULT NULL::CHARACTER VARYING,
+    lastinvoicereference  VARCHAR(50) DEFAULT NULL::CHARACTER VARYING,
+    createdbyuser_id      INTEGER
 );
 
-comment on column report.type is '(DC2Type:refdata)';
+COMMENT ON COLUMN supervision_finance.report.type IS '(DC2Type:refdata)';
 
-comment on column report.totalamount is '(DC2Type:money)';
+COMMENT ON COLUMN supervision_finance.report.totalamount IS '(DC2Type:money)';
 
-alter table report
-    owner to api;
+ALTER TABLE supervision_finance.report
+    OWNER TO api;
 
-create index idx_819a1c8ae1f44b34
-    on report (createdbyuser_id);
+CREATE INDEX idx_819a1c8ae1f44b34
+    ON supervision_finance.report (createdbyuser_id);
 
-create unique index uniq_819a1c8a36967d99
-    on report (batchnumber);
+CREATE UNIQUE INDEX uniq_819a1c8a36967d99
+    ON supervision_finance.report (batchnumber);
 
 -- +goose Down
 

--- a/migrations/20240410093925_invoice_created_fields.sql
+++ b/migrations/20240410093925_invoice_created_fields.sql
@@ -1,7 +1,7 @@
 -- +goose Up
-ALTER TABLE invoice ADD COLUMN createddate date;
-ALTER TABLE invoice ADD COLUMN createdby_id integer;
+ALTER TABLE supervision_finance.invoice ADD COLUMN createddate date;
+ALTER TABLE supervision_finance.invoice ADD COLUMN createdby_id integer;
 
 -- +goose Down
-ALTER TABLE invoice DROP COLUMN createddate;
-ALTER TABLE invoice DROP COLUMN createdby_id;
+ALTER TABLE supervision_finance.invoice DROP COLUMN createddate;
+ALTER TABLE supervision_finance.invoice DROP COLUMN createdby_id;

--- a/migrations/20240410094040_ledger_allocation_type.sql
+++ b/migrations/20240410094040_ledger_allocation_type.sql
@@ -1,5 +1,5 @@
 -- +goose Up
-ALTER TABLE ledger_allocation ADD COLUMN transaction_type varchar(255);
+ALTER TABLE supervision_finance.ledger_allocation ADD COLUMN transaction_type varchar(255);
 
 -- +goose Down
-ALTER TABLE ledger_allocation DROP COLUMN transaction_type;
+ALTER TABLE supervision_finance.ledger_allocation DROP COLUMN transaction_type;

--- a/migrations/20240410094117_ledger_created_fields.sql
+++ b/migrations/20240410094117_ledger_created_fields.sql
@@ -1,7 +1,7 @@
 -- +goose Up
-ALTER TABLE ledger ADD COLUMN createddate date;
-ALTER TABLE ledger ADD COLUMN createdby_id int;
+ALTER TABLE supervision_finance.ledger ADD COLUMN createddate date;
+ALTER TABLE supervision_finance.ledger ADD COLUMN createdby_id int;
 
 -- +goose Down
-ALTER TABLE ledger DROP COLUMN createddate;
-ALTER TABLE ledger DROP COLUMN createdby_id;
+ALTER TABLE supervision_finance.ledger DROP COLUMN createddate;
+ALTER TABLE supervision_finance.ledger DROP COLUMN createdby_id;

--- a/migrations/20240502060448_invoice_fee_reduction_id.sql
+++ b/migrations/20240502060448_invoice_fee_reduction_id.sql
@@ -1,5 +1,5 @@
 -- +goose Up
-ALTER TABLE invoice ADD COLUMN fee_reduction_id integer;
+ALTER TABLE supervision_finance.invoice ADD COLUMN fee_reduction_id integer;
 
 -- +goose Down
-ALTER TABLE invoice ADD COLUMN fee_reduction_id integer;
+ALTER TABLE supervision_finance.invoice ADD COLUMN fee_reduction_id integer;

--- a/test-data/seed_data.sql
+++ b/test-data/seed_data.sql
@@ -1,3 +1,7 @@
+SET SEARCH_PATH TO public;
+
+INSERT INTO assignees VALUES (65, 'Finance', 'assignee_user', 'finance.manager@opgtest.com', 'Manager', '"{""OPG User"":""OPG User"",""Case Manager"":""Case Manager"",""Finance Manager"":""Finance Manager""}"', false, '12345678', NULL, NULL, '2024-06-13 13:19:37', false);
+
 SET SEARCH_PATH TO supervision_finance;
 
 INSERT INTO finance_client VALUES (1, 1, '1234', 'DEMANDED', null);


### PR DESCRIPTION
These would be the proposed changes from the Payments side if we were going to query the assignees table directly. The user and roles changes would be on the infra side and the user would be passed in in environment variables as usual.

Technically, these changes would work without the role restrictions as the sole DB user has access to everything anyway.

An alternative to these changes (assuming we still go with a DB solution as opposed to an API) would be to maintain two DB connections, and read the schemas separately with two separate SQLC instances. This would potentially be slightly more complex architecturally but would remove the need for the vast majority of these changes, allow migrations to still be scoped by search path to prevent unwanted changes, etc.

A third, slightly more involved suggestion would be to move the assignees table out into a new schema - e.g. `identity` - and then use  search path to only access those two schemas. This is probably unnecessary but could add another level of security, even if set at a user level as opposed to connection.