### PR TITLE
L&D experiment on replacing JS with Hyperscript

### DIFF
--- a/finance-hub/package.json
+++ b/finance-hub/package.json
@@ -18,8 +18,9 @@
     "@cypress/grep": "^4.0.1",
     "@ministryofjustice/frontend": "^2.1.0",
     "govuk-frontend": "^5.0.0",
-    "opg-sirius-header": "ministryofjustice/opg-sirius-header#semver:v0.17.0",
-    "htmx.org": "^1.9.10"
+    "htmx.org": "^1.9.10",
+    "hyperscript.org": "^0.9.12",
+    "opg-sirius-header": "ministryofjustice/opg-sirius-header#semver:v0.17.0"
   },
   "devDependencies": {
     "esbuild": "^0.19.0",

--- a/finance-hub/web/assets/main.js
+++ b/finance-hub/web/assets/main.js
@@ -1,6 +1,9 @@
 import {initAll} from 'govuk-frontend'
 import "govuk-frontend/dist/govuk/all.mjs";
 import "opg-sirius-header/sirius-header.js";
+import _hyperscript from "hyperscript.org";
+
+_hyperscript.browserInit();
 
 document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
 initAll();
@@ -16,32 +19,11 @@ document.body.addEventListener('htmx:beforeOnLoad', function (evt) {
         evt.detail.shouldSwap = true;
         evt.detail.isError = false;
     }
-
-    // clear the previous validation messages before load so the new ones can be swapped in
-    document.querySelectorAll(".govuk-error-message").forEach((element) => {
-        element.remove();
-    });
 });
 
 // adding event listeners inside the onLoad function will ensure they are re-added to partial content when loaded back in
 htmx.onLoad(content => {
     initAll();
-
-    htmx.findAll(content, ".summary").forEach((element => {
-        htmx.on(`#${element.id}`, "click", () => htmx.toggleClass(htmx.find(`#${element.id}-reveal`), "hide"));
-    }));
-
-    htmx.findAll(".show-input-field").forEach((element) => {
-        element.addEventListener("click", () => htmx.removeClass(htmx.find("#field-input"), "hide"));
-    });
-
-    htmx.findAll(".hide-input-field").forEach((element) => {
-        element.addEventListener("click", () => htmx.addClass(htmx.find("#field-input"), "hide"));
-    });
-
-    htmx.findAll(".moj-banner--success").forEach((element) => {
-        element.addEventListener("click", () => htmx.addClass(htmx.find(".moj-banner--success"), "hide"));
-    });
 
     // validation errors are loaded in as a partial, with oob-swaps for the field error messages,
     // but classes need to be applied to each form group that appears in the summary

--- a/finance-hub/web/template/adjust-invoice.gotmpl
+++ b/finance-hub/web/template/adjust-invoice.gotmpl
@@ -32,7 +32,14 @@
                                 <div class="govuk-radios" data-module="govuk-radios">
                                     {{ range .AdjustmentTypes }}
                                         <div class="govuk-radios__item">
-                                            <input class="govuk-radios__input {{ if .AmountRequired }}show{{else}}hide{{ end }}-input-field" id="{{.Key}}" name="adjustmentType"
+                                            <input class="govuk-radios__input {{ if .AmountRequired }}show{{else}}hide{{ end }}-input-field"
+                                                   _="on click
+                                                        if {{ .AmountRequired }}
+                                                            remove .hide from #field-input
+                                                        else
+                                                            add .hide to #field-input
+                                                    "
+                                                   id="{{.Key}}" name="adjustmentType"
                                                    type="radio" value="{{.Key}}">
                                             <label class="govuk-label govuk-radios__label"
                                                    for="{{.Key}}">{{.Translation}}</label>

--- a/finance-hub/web/template/layout/error-summary.gotmpl
+++ b/finance-hub/web/template/layout/error-summary.gotmpl
@@ -26,7 +26,8 @@
     {{ range $k, $v := .Errors }}
         <span id="error-message__{{$k}}" hx-swap-oob="true">
                 {{ range $type, $error := $v }}
-                    <p id="name-error{{ if $type}}-{{ $type }}{{ end }}" class="govuk-error-message">
+                    <p id="name-error{{ if $type}}-{{ $type }}{{ end }}" class="govuk-error-message"
+                       _="on every htmx:oobBeforeSwap remove me then log 'Loaded!'">
                       <span class="govuk-visually-hidden">Error:</span> {{ $error }}
                     </p>
                 {{ end }}

--- a/finance-hub/web/template/layout/success-banner.gotmpl
+++ b/finance-hub/web/template/layout/success-banner.gotmpl
@@ -1,5 +1,5 @@
 {{ define "success-banner" }}
-    <div class="moj-banner moj-banner--success">
+    <div id="success-banner" class="moj-banner moj-banner--success">
         <svg
             class="moj-banner__icon"
             fill="currentColor"
@@ -15,7 +15,7 @@
         <div class="moj-banner__message moj-success-banner">
             <span class="moj-banner__assistive">Success</span>
             {{ .SuccessMessage }}
-            <a class="govuk-link">Close</a>
+            <button class="govuk-link" _="on click remove #success-banner">Close</button>
         </div>
     </div>
 {{ end }}

--- a/finance-hub/web/template/tabs/invoices-list.gotmpl
+++ b/finance-hub/web/template/tabs/invoices-list.gotmpl
@@ -33,7 +33,8 @@
           {{  range .Invoices }}
             <tr class="govuk-table__row">
               <td class="govuk-table__cell" >
-                <details class="govuk-details summary" id="invoice-{{.Id}}">
+                <details class="govuk-details summary" id="invoice-{{.Id}}"
+                  _="on click toggle .hide on next .summary-details">
                   <summary class="govuk-details__summary">
                     <span class="govuk-details__summary-text" data-cy="ref">
                       {{- .Ref -}}
@@ -64,7 +65,7 @@
               </td>
             </tr>
 
-            <tr class="hide" id="invoice-{{.Id}}-reveal">
+            <tr class="hide summary-details">
               <td class="govuk-table__cell" colspan="4">
                 {{ template "invoice-ledger-allocations" .Ledgers }}
                 {{ template "supervision-levels" .SupervisionLevels }}

--- a/finance-hub/yarn.lock
+++ b/finance-hub/yarn.lock
@@ -199,6 +199,46 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz"
   integrity sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==
 
+"@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
+  integrity sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==
+  dependencies:
+    "@jridgewell/set-array" "^1.2.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
+"@jridgewell/set-array@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
+  integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
+
+"@jridgewell/source-map@^0.3.3":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.6.tgz#9d71ca886e32502eb9362c9a74a46787c36df81a"
+  integrity sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
+  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
 "@ministryofjustice/frontend@^2.1.0":
   version "2.1.0"
   resolved "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-2.1.0.tgz"
@@ -242,6 +282,11 @@ acorn-walk@^8.2.0:
   version "8.3.2"
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz"
   integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
+
+acorn@^8.8.2:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.0.tgz#1627bfa2e058148036133b8d9b51a700663c294c"
+  integrity sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==
 
 acorn@^8.9.0:
   version "8.11.3"
@@ -313,6 +358,11 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
@@ -357,6 +407,11 @@ colors@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -678,6 +733,14 @@ htmx.org@^1.9.10:
   resolved "https://registry.npmjs.org/htmx.org/-/htmx.org-1.9.10.tgz"
   integrity sha512-UgchasltTCrTuU2DQLom3ohHrBvwr7OqpwyAVJ9VxtNBng4XKkVsqrv0Qr3srqvM9ZNI3f1MmvVQQqK7KW/bTA==
 
+hyperscript.org@^0.9.12:
+  version "0.9.12"
+  resolved "https://registry.yarnpkg.com/hyperscript.org/-/hyperscript.org-0.9.12.tgz#60605e57f783fc367c8d1c8171b680b36181736c"
+  integrity sha512-fLtS+FVayzLUdgC4w00oozg0uickzUyJIbyKg0fB7vSGkUfsY2itGl/XsTcVFahufp41oN5OFFmRXMxoIZ97Og==
+  dependencies:
+    markdown-it-deflist "^2.1.0"
+    terser "^5.14.1"
+
 ignore@^5.2.0:
   version "5.3.1"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz"
@@ -796,6 +859,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+markdown-it-deflist@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-deflist/-/markdown-it-deflist-2.1.0.tgz#50d7a56b9544cd81252f7623bd785e28a8dcef5c"
+  integrity sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg==
 
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
@@ -1002,6 +1070,19 @@ slash@^3.0.0:
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map-support@~0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
@@ -1020,6 +1101,16 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+terser@^5.14.1:
+  version "5.31.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.1.tgz#735de3c987dd671e95190e6b98cfe2f07f3cf0d4"
+  integrity sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Hyperscript is a JS library developed by the same team as HTMX along the same principles, with "Locality of Behaviour" being key. Rather than having JS in a separate file affecting HTML elsewhere, the intention is to keep the code that affects change in the same location as the elements that need changing.

It does this with a natural language approach. In a lot of ways, it is simpler than much of the JS it is replacing and it is easy to see at a glance what it is doing. Writing it however is harder, as it is effectively a whole new language, which is a barrier to adoption. I was able to replace most of the JS, including for opening and closing the additional details in the Invoices table, but found it hard to work out the syntax to replace the error validation handling.

Another benefit of Hyperscript and Locality of Behaviour is the code is included in the HTML returned from the server. This gets round the issue of needing to place all scripts within the `htmx.onLoad` function to reestablish event listeners.