### PR TITLE
PFS-274: Gosec fixes

### DIFF
--- a/finance-api/cmd/api/add_fee_reduction.go
+++ b/finance-api/cmd/api/add_fee_reduction.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) addFeeReduction(w http.ResponseWriter, r *http.Request) error {
@@ -23,8 +22,12 @@ func (s *Server) addFeeReduction(w http.ResponseWriter, r *http.Request) error {
 		return validationError
 	}
 
-	clientId, _ := strconv.Atoi(r.PathValue("clientId"))
-	err := s.service.AddFeeReduction(ctx, clientId, addFeeReduction)
+	clientId, err := s.getPathID(r, "clientId")
+	if err != nil {
+		return err
+	}
+
+	err = s.service.AddFeeReduction(ctx, clientId, addFeeReduction)
 
 	if err != nil {
 		return err

--- a/finance-api/cmd/api/add_invoice_adjustment.go
+++ b/finance-api/cmd/api/add_invoice_adjustment.go
@@ -4,14 +4,19 @@ import (
 	"encoding/json"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) AddInvoiceAdjustment(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	clientId, _ := strconv.Atoi(r.PathValue("clientId"))
-	invoiceId, _ := strconv.Atoi(r.PathValue("invoiceId"))
+	clientId, err := s.getPathID(r, "clientId")
+	if err != nil {
+		return err
+	}
+	invoiceId, err := s.getPathID(r, "invoiceId")
+	if err != nil {
+		return err
+	}
 
 	var ledgerEntry shared.AddInvoiceAdjustmentRequest
 	if err := json.NewDecoder(r.Body).Decode(&ledgerEntry); err != nil {

--- a/finance-api/cmd/api/add_manual_invoice.go
+++ b/finance-api/cmd/api/add_manual_invoice.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) addManualInvoice(w http.ResponseWriter, r *http.Request) error {
@@ -23,8 +22,12 @@ func (s *Server) addManualInvoice(w http.ResponseWriter, r *http.Request) error 
 		return validationError
 	}
 
-	clientId, _ := strconv.Atoi(r.PathValue("clientId"))
-	err := s.service.AddManualInvoice(ctx, clientId, addManualInvoice)
+	clientId, err := s.getPathID(r, "clientId")
+	if err != nil {
+		return err
+	}
+
+	err = s.service.AddManualInvoice(ctx, clientId, addManualInvoice)
 
 	if err != nil {
 		return err

--- a/finance-api/cmd/api/add_manual_invoice_test.go
+++ b/finance-api/cmd/api/add_manual_invoice_test.go
@@ -23,7 +23,7 @@ func TestServer_addManualInvoice(t *testing.T) {
 
 	manualInvoiceInfo := &shared.AddManualInvoice{
 		InvoiceType:      shared.InvoiceTypeS2,
-		Amount:           shared.Nillable[int]{Value: 32000, Valid: true},
+		Amount:           shared.Nillable[int32]{Value: 32000, Valid: true},
 		RaisedDate:       shared.Nillable[shared.Date]{Value: shared.Date{Time: endDateToTime}, Valid: true},
 		StartDate:        shared.Nillable[shared.Date]{Value: shared.Date{Time: startDateToTime}, Valid: true},
 		EndDate:          shared.Nillable[shared.Date]{Value: shared.Date{Time: endDateToTime}, Valid: true},
@@ -54,7 +54,7 @@ func TestServer_addManualInvoiceNoValidationErrorsForNilFields(t *testing.T) {
 	var b bytes.Buffer
 	manualInvoiceInfo := &shared.AddManualInvoice{
 		InvoiceType:      shared.InvoiceTypeAD,
-		Amount:           shared.Nillable[int]{},
+		Amount:           shared.Nillable[int32]{},
 		RaisedDate:       shared.Nillable[shared.Date]{},
 		StartDate:        shared.Nillable[shared.Date]{},
 		EndDate:          shared.Nillable[shared.Date]{},
@@ -85,7 +85,7 @@ func TestServer_addManualInvoiceValidationErrors(t *testing.T) {
 
 	manualInvoiceInfo := &shared.AddManualInvoice{
 		InvoiceType:      shared.InvoiceTypeUnknown,
-		Amount:           shared.Nillable[int]{Valid: true},
+		Amount:           shared.Nillable[int32]{Valid: true},
 		RaisedDate:       shared.Nillable[shared.Date]{Valid: true},
 		StartDate:        shared.Nillable[shared.Date]{Valid: true},
 		EndDate:          shared.Nillable[shared.Date]{Valid: true},
@@ -133,7 +133,7 @@ func TestServer_addManualInvoiceValidationErrorsForAmountTooHigh(t *testing.T) {
 
 	manualInvoiceInfo := &shared.AddManualInvoice{
 		InvoiceType:      shared.InvoiceTypeS2,
-		Amount:           shared.Nillable[int]{Value: 320000, Valid: true},
+		Amount:           shared.Nillable[int32]{Value: 320000, Valid: true},
 		RaisedDate:       shared.Nillable[shared.Date]{Value: shared.Date{Time: endDateToTime}, Valid: true},
 		StartDate:        shared.Nillable[shared.Date]{Value: shared.Date{Time: startDateToTime}, Valid: true},
 		EndDate:          shared.Nillable[shared.Date]{Value: shared.Date{Time: endDateToTime}, Valid: true},
@@ -166,7 +166,7 @@ func TestServer_addManualInvoiceDateErrors(t *testing.T) {
 
 	manualInvoiceInfo := &shared.AddManualInvoice{
 		InvoiceType:      shared.InvoiceTypeS2,
-		Amount:           shared.Nillable[int]{Value: 320000, Valid: true},
+		Amount:           shared.Nillable[int32]{Value: 320000, Valid: true},
 		RaisedDate:       shared.Nillable[shared.Date]{Value: shared.Date{Time: endDateToTime}, Valid: true},
 		StartDate:        shared.Nillable[shared.Date]{Value: shared.Date{Time: startDateToTime}, Valid: true},
 		EndDate:          shared.Nillable[shared.Date]{Value: shared.Date{Time: endDateToTime}, Valid: true},
@@ -198,7 +198,7 @@ func TestServer_addManualInvoice422Error(t *testing.T) {
 
 	manualInvoiceInfo := &shared.AddManualInvoice{
 		InvoiceType:      shared.InvoiceTypeS2,
-		Amount:           shared.Nillable[int]{Value: 32000, Valid: true},
+		Amount:           shared.Nillable[int32]{Value: 32000, Valid: true},
 		RaisedDate:       shared.Nillable[shared.Date]{Value: shared.Date{Time: endDateToTime}, Valid: true},
 		StartDate:        shared.Nillable[shared.Date]{Value: shared.Date{Time: startDateToTime}, Valid: true},
 		EndDate:          shared.Nillable[shared.Date]{Value: shared.Date{Time: endDateToTime}, Valid: true},

--- a/finance-api/cmd/api/auth.go
+++ b/finance-api/cmd/api/auth.go
@@ -25,10 +25,10 @@ func (s *Server) authenticate(h http.Handler) http.HandlerFunc {
 		}
 
 		claims := token.Claims.(*auth.Claims)
-		userID, _ := strconv.Atoi(claims.ID)
+		userID, _ := strconv.ParseInt(claims.ID, 10, 32)
 
 		ctx.User = &shared.User{
-			ID:    userID,
+			ID:    int32(userID),
 			Roles: claims.Roles,
 		}
 

--- a/finance-api/cmd/api/billing_history.go
+++ b/finance-api/cmd/api/billing_history.go
@@ -3,13 +3,16 @@ package api
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) getBillingHistory(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	clientId, _ := strconv.Atoi(r.PathValue("clientId"))
+	clientId, err := s.getPathID(r, "clientId")
+	if err != nil {
+		return err
+	}
+
 	billingHistory, err := s.service.GetBillingHistory(ctx, clientId)
 
 	if err != nil {

--- a/finance-api/cmd/api/cancel_fee_reduction.go
+++ b/finance-api/cmd/api/cancel_fee_reduction.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) cancelFeeReduction(w http.ResponseWriter, r *http.Request) error {
@@ -23,8 +22,12 @@ func (s *Server) cancelFeeReduction(w http.ResponseWriter, r *http.Request) erro
 		return validationError
 	}
 
-	feeReductionId, _ := strconv.Atoi(r.PathValue("feeReductionId"))
-	err := s.service.CancelFeeReduction(ctx, feeReductionId, cancelFeeReduction)
+	feeReductionId, err := s.getPathID(r, "feeReductionId")
+	if err != nil {
+		return err
+	}
+
+	err = s.service.CancelFeeReduction(ctx, feeReductionId, cancelFeeReduction)
 
 	if err != nil {
 		return err

--- a/finance-api/cmd/api/fee_reductions.go
+++ b/finance-api/cmd/api/fee_reductions.go
@@ -3,13 +3,16 @@ package api
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) getFeeReductions(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	clientId, _ := strconv.Atoi(r.PathValue("clientId"))
+	clientId, err := s.getPathID(r, "clientId")
+	if err != nil {
+		return err
+	}
+
 	accountInfo, err := s.service.GetFeeReductions(ctx, clientId)
 	if err != nil {
 		return err

--- a/finance-api/cmd/api/finance_clients.go
+++ b/finance-api/cmd/api/finance_clients.go
@@ -6,13 +6,16 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/apierror"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) getAccountInformation(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	clientId, _ := strconv.Atoi(r.PathValue("clientId"))
+	clientId, err := s.getPathID(r, "clientId")
+	if err != nil {
+		return err
+	}
+
 	accountInfo, err := s.service.GetAccountInformation(ctx, clientId)
 
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/finance-api/cmd/api/handle_events.go
+++ b/finance-api/cmd/api/handle_events.go
@@ -21,7 +21,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) error {
 
 	if event.Source == shared.EventSourceSirius && event.DetailType == shared.DetailTypeDebtPositionChanged {
 		if detail, ok := event.Detail.(shared.DebtPositionChangedEvent); ok {
-			err := s.service.ReapplyCredit(ctx, int32(detail.ClientID))
+			err := s.service.ReapplyCredit(ctx, detail.ClientID)
 			if err != nil {
 				return err
 			}

--- a/finance-api/cmd/api/invoice_adjustments.go
+++ b/finance-api/cmd/api/invoice_adjustments.go
@@ -3,13 +3,16 @@ package api
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) getInvoiceAdjustments(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	clientId, _ := strconv.Atoi(r.PathValue("clientId"))
+	clientId, err := s.getPathID(r, "clientId")
+	if err != nil {
+		return err
+	}
+
 	data, err := s.service.GetInvoiceAdjustments(ctx, clientId)
 
 	if err != nil {

--- a/finance-api/cmd/api/invoices.go
+++ b/finance-api/cmd/api/invoices.go
@@ -3,13 +3,16 @@ package api
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) getInvoices(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	clientId, _ := strconv.Atoi(r.PathValue("clientId"))
+	clientId, err := s.getPathID(r, "clientId")
+	if err != nil {
+		return err
+	}
+
 	invoices, err := s.service.GetInvoices(ctx, clientId)
 
 	if err != nil {

--- a/finance-api/cmd/api/permitted_adjustments.go
+++ b/finance-api/cmd/api/permitted_adjustments.go
@@ -6,13 +6,16 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/apierror"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) getPermittedAdjustments(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	invoiceId, _ := strconv.Atoi(r.PathValue("invoiceId"))
+	invoiceId, err := s.getPathID(r, "invoiceId")
+	if err != nil {
+		return err
+	}
+
 	types, err := s.service.GetPermittedAdjustments(ctx, invoiceId)
 
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/finance-api/cmd/api/server_test.go
+++ b/finance-api/cmd/api/server_test.go
@@ -25,7 +25,7 @@ type mockService struct {
 	err                error
 }
 
-func (s *mockService) UpdatePaymentMethod(ctx context.Context, clientID int, paymentMethod shared.PaymentMethod) error {
+func (s *mockService) UpdatePaymentMethod(ctx context.Context, clientID int32, paymentMethod shared.PaymentMethod) error {
 	s.expectedIds = []int{int(clientID)}
 	s.lastCalled = "UpdatePaymentMethod"
 	return s.err
@@ -37,69 +37,69 @@ func (s *mockService) ReapplyCredit(ctx context.Context, clientID int32) error {
 	return s.err
 }
 
-func (s *mockService) GetBillingHistory(ctx context.Context, id int) ([]shared.BillingHistory, error) {
-	s.expectedIds = []int{id}
+func (s *mockService) GetBillingHistory(ctx context.Context, id int32) ([]shared.BillingHistory, error) {
+	s.expectedIds = []int{int(id)}
 	s.lastCalled = "GetBillingHistory"
 	return s.billingHistory, s.err
 }
 
-func (s *mockService) AddManualInvoice(ctx context.Context, id int, invoice shared.AddManualInvoice) error {
-	s.expectedIds = []int{id}
+func (s *mockService) AddManualInvoice(ctx context.Context, id int32, invoice shared.AddManualInvoice) error {
+	s.expectedIds = []int{int(id)}
 	s.lastCalled = "AddManualInvoice"
 	return s.err
 }
 
-func (s *mockService) GetPermittedAdjustments(ctx context.Context, invoiceId int) ([]shared.AdjustmentType, error) {
-	s.expectedIds = []int{invoiceId}
+func (s *mockService) GetPermittedAdjustments(ctx context.Context, id int32) ([]shared.AdjustmentType, error) {
+	s.expectedIds = []int{int(id)}
 	s.lastCalled = "GetPermittedAdjustments"
 	return s.adjustmentTypes, s.err
 }
 
-func (s *mockService) UpdatePendingInvoiceAdjustment(ctx context.Context, clientId int, adjustmentId int, status shared.AdjustmentStatus) error {
-	s.expectedIds = []int{adjustmentId}
+func (s *mockService) UpdatePendingInvoiceAdjustment(ctx context.Context, clientId int32, adjustmentId int32, status shared.AdjustmentStatus) error {
+	s.expectedIds = []int{int(adjustmentId)}
 	s.lastCalled = "UpdatePendingInvoiceAdjustment"
 	return s.err
 }
 
-func (s *mockService) AddFeeReduction(ctx context.Context, id int, data shared.AddFeeReduction) error {
-	s.expectedIds = []int{id}
+func (s *mockService) AddFeeReduction(ctx context.Context, id int32, data shared.AddFeeReduction) error {
+	s.expectedIds = []int{int(id)}
 	s.lastCalled = "AddFeeReduction"
 	return s.err
 }
 
-func (s *mockService) CancelFeeReduction(ctx context.Context, id int, cancelledFeeReduction shared.CancelFeeReduction) error {
-	s.expectedIds = []int{id}
+func (s *mockService) CancelFeeReduction(ctx context.Context, id int32, cancelledFeeReduction shared.CancelFeeReduction) error {
+	s.expectedIds = []int{int(id)}
 	s.lastCalled = "CancelFeeReduction"
 	return s.err
 }
 
-func (s *mockService) GetAccountInformation(ctx context.Context, id int) (*shared.AccountInformation, error) {
-	s.expectedIds = []int{id}
+func (s *mockService) GetAccountInformation(ctx context.Context, id int32) (*shared.AccountInformation, error) {
+	s.expectedIds = []int{int(id)}
 	s.lastCalled = "GetAccountInformation"
 	return s.accountInfo, s.err
 }
 
-func (s *mockService) GetInvoices(ctx context.Context, id int) (*shared.Invoices, error) {
-	s.expectedIds = []int{id}
+func (s *mockService) GetInvoices(ctx context.Context, id int32) (*shared.Invoices, error) {
+	s.expectedIds = []int{int(id)}
 	s.lastCalled = "GetInvoices"
 	return s.invoices, s.err
 }
 
-func (s *mockService) GetFeeReductions(ctx context.Context, id int) (*shared.FeeReductions, error) {
-	s.expectedIds = []int{id}
+func (s *mockService) GetFeeReductions(ctx context.Context, id int32) (*shared.FeeReductions, error) {
+	s.expectedIds = []int{int(id)}
 	s.lastCalled = "GetFeeReductions"
 	return s.feeReductions, s.err
 }
 
-func (s *mockService) GetInvoiceAdjustments(ctx context.Context, id int) (*shared.InvoiceAdjustments, error) {
-	s.expectedIds = []int{id}
+func (s *mockService) GetInvoiceAdjustments(ctx context.Context, id int32) (*shared.InvoiceAdjustments, error) {
+	s.expectedIds = []int{int(id)}
 	s.lastCalled = "GetInvoiceAdjustments"
 	return s.invoiceAdjustments, s.err
 }
 
-func (s *mockService) AddInvoiceAdjustment(ctx context.Context, clientId int, invoiceId int, ledgerEntry *shared.AddInvoiceAdjustmentRequest) (*shared.InvoiceReference, error) {
+func (s *mockService) AddInvoiceAdjustment(ctx context.Context, clientId int32, invoiceId int32, ledgerEntry *shared.AddInvoiceAdjustmentRequest) (*shared.InvoiceReference, error) {
 	s.ledger = ledgerEntry
-	s.expectedIds = []int{clientId, invoiceId}
+	s.expectedIds = []int{int(clientId), int(invoiceId)}
 	s.lastCalled = "AddInvoiceAdjustment"
 	return s.invoiceReference, s.err
 }
@@ -109,7 +109,7 @@ func (s *mockService) ProcessFinanceAdminUpload(ctx context.Context, detail shar
 	return s.err
 }
 
-func (s *mockService) UpdateClient(ctx context.Context, clientId int, courtRef string) error {
+func (s *mockService) UpdateClient(ctx context.Context, clientId int32, courtRef string) error {
 	s.lastCalled = "UpdateClient"
 	return s.err
 }

--- a/finance-api/cmd/api/update_payment_method.go
+++ b/finance-api/cmd/api/update_payment_method.go
@@ -4,15 +4,12 @@ import (
 	"encoding/json"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) updatePaymentMethod(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
 	var body shared.UpdatePaymentMethod
-
-	clientId, _ := strconv.Atoi(r.PathValue("clientId"))
 
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		return err
@@ -24,7 +21,12 @@ func (s *Server) updatePaymentMethod(w http.ResponseWriter, r *http.Request) err
 		return validationError
 	}
 
-	err := s.service.UpdatePaymentMethod(ctx, clientId, body.PaymentMethod)
+	clientId, err := s.getPathID(r, "clientId")
+	if err != nil {
+		return err
+	}
+
+	err = s.service.UpdatePaymentMethod(ctx, clientId, body.PaymentMethod)
 
 	if err != nil {
 		return err

--- a/finance-api/cmd/api/update_pending_invoice_adjustment.go
+++ b/finance-api/cmd/api/update_pending_invoice_adjustment.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 	"net/http"
-	"strconv"
 )
 
 func (s *Server) updatePendingInvoiceAdjustment(w http.ResponseWriter, r *http.Request) error {
@@ -12,8 +11,15 @@ func (s *Server) updatePendingInvoiceAdjustment(w http.ResponseWriter, r *http.R
 
 	var body shared.UpdateInvoiceAdjustment
 
-	clientId, _ := strconv.Atoi(r.PathValue("clientId"))
-	adjustmentId, _ := strconv.Atoi(r.PathValue("adjustmentId"))
+	clientId, err := s.getPathID(r, "clientId")
+	if err != nil {
+		return err
+	}
+
+	adjustmentId, err := s.getPathID(r, "adjustmentId")
+	if err != nil {
+		return err
+	}
 
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		return err
@@ -25,7 +31,7 @@ func (s *Server) updatePendingInvoiceAdjustment(w http.ResponseWriter, r *http.R
 		return validationError
 	}
 
-	err := s.service.UpdatePendingInvoiceAdjustment(ctx, clientId, adjustmentId, body.Status)
+	err = s.service.UpdatePendingInvoiceAdjustment(ctx, clientId, adjustmentId, body.Status)
 
 	if err != nil {
 		return err

--- a/finance-api/internal/reports/client.go
+++ b/finance-api/internal/reports/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/notify"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -60,7 +61,7 @@ func (c *Client) generate(ctx context.Context, filename string, query db.ReportQ
 }
 
 func createCsv(filename string, items [][]string) (*os.File, error) {
-	file, err := os.Create(filename)
+	file, err := os.Create(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
 	}

--- a/finance-api/internal/service/add_invoice_adjustment_test.go
+++ b/finance-api/internal/service/add_invoice_adjustment_test.go
@@ -28,8 +28,8 @@ func (suite *IntegrationSuite) TestService_AddInvoiceAdjustment() {
 
 	testCases := []struct {
 		name      string
-		invoiceId int
-		clientId  int
+		invoiceId int32
+		clientId  int32
 		data      *shared.AddInvoiceAdjustmentRequest
 		err       error
 	}{

--- a/finance-api/internal/service/add_manual_invoice.go
+++ b/finance-api/internal/service/add_manual_invoice.go
@@ -15,11 +15,11 @@ import (
 func processInvoiceData(data shared.AddManualInvoice) shared.AddManualInvoice {
 	switch data.InvoiceType {
 	case shared.InvoiceTypeAD:
-		data.Amount = shared.Nillable[int]{Value: 10000, Valid: true}
+		data.Amount = shared.Nillable[int32]{Value: 10000, Valid: true}
 		data.StartDate = data.RaisedDate
 		data.EndDate = data.RaisedDate
 	case shared.InvoiceTypeGA:
-		data.Amount = shared.Nillable[int]{Value: 20000, Valid: true}
+		data.Amount = shared.Nillable[int32]{Value: 20000, Valid: true}
 		data.StartDate = data.RaisedDate
 		data.EndDate = data.RaisedDate
 	case shared.InvoiceTypeS2, shared.InvoiceTypeB2:
@@ -33,7 +33,7 @@ func processInvoiceData(data shared.AddManualInvoice) shared.AddManualInvoice {
 	return data
 }
 
-func (s *Service) AddManualInvoice(ctx context.Context, clientId int, data shared.AddManualInvoice) error {
+func (s *Service) AddManualInvoice(ctx context.Context, clientId int32, data shared.AddManualInvoice) error {
 	data = processInvoiceData(data)
 	validationErrors := s.validateManualInvoice(data)
 
@@ -56,16 +56,32 @@ func (s *Service) AddManualInvoice(ctx context.Context, clientId int, data share
 
 	invoiceRef := addLeadingZeros(counter)
 
+	var (
+		personID   pgtype.Int4
+		startDate  pgtype.Date
+		endDate    pgtype.Date
+		raisedDate pgtype.Date
+		source     pgtype.Text
+		createdBy  pgtype.Int4
+	)
+
+	_ = store.ToInt4(&personID, clientId)
+	_ = startDate.Scan(data.StartDate.Value.Time)
+	_ = endDate.Scan(data.EndDate.Value.Time)
+	_ = raisedDate.Scan(data.RaisedDate.Value.Time)
+	_ = source.Scan("Created manually")
+	_ = store.ToInt4(&createdBy, ctx.(auth.Context).User.ID)
+
 	invoiceParams := store.AddInvoiceParams{
-		PersonID:   pgtype.Int4{Int32: int32(clientId), Valid: true},
+		PersonID:   personID,
 		Feetype:    data.InvoiceType.Key(),
 		Reference:  data.InvoiceType.Key() + invoiceRef + "/" + strconv.Itoa(data.StartDate.Value.Time.Year()%100),
-		Startdate:  pgtype.Date{Time: data.StartDate.Value.Time, Valid: true},
-		Enddate:    pgtype.Date{Time: data.EndDate.Value.Time, Valid: true},
-		Amount:     int32(data.Amount.Value),
-		Raiseddate: pgtype.Date{Time: data.RaisedDate.Value.Time, Valid: true},
-		Source:     pgtype.Text{String: "Created manually", Valid: true},
-		CreatedBy:  pgtype.Int4{Int32: int32(ctx.(auth.Context).User.ID), Valid: true},
+		Startdate:  startDate,
+		Enddate:    endDate,
+		Amount:     data.Amount.Value,
+		Raiseddate: raisedDate,
+		Source:     source,
+		CreatedBy:  createdBy,
 	}
 
 	var invoice store.Invoice
@@ -74,12 +90,22 @@ func (s *Service) AddManualInvoice(ctx context.Context, clientId int, data share
 		return err
 	}
 
+	var (
+		invoiceID pgtype.Int4
+		fromDate  pgtype.Date
+		toDate    pgtype.Date
+	)
+
+	_ = store.ToInt4(&invoiceID, invoice.ID)
+	_ = fromDate.Scan(data.StartDate.Value.Time)
+	_ = toDate.Scan(data.EndDate.Value.Time)
+
 	if data.SupervisionLevel.Valid {
 		addInvoiceRangeQueryArgs := store.AddInvoiceRangeParams{
-			InvoiceID:        pgtype.Int4{Int32: invoice.ID, Valid: true},
+			InvoiceID:        invoiceID,
 			Supervisionlevel: strings.ToUpper(data.SupervisionLevel.Value),
-			Fromdate:         pgtype.Date{Time: data.StartDate.Value.Time, Valid: true},
-			Todate:           pgtype.Date{Time: data.EndDate.Value.Time, Valid: true},
+			Fromdate:         fromDate,
+			Todate:           toDate,
 			Amount:           invoice.Amount,
 		}
 
@@ -90,7 +116,7 @@ func (s *Service) AddManualInvoice(ctx context.Context, clientId int, data share
 	}
 
 	reductionForDateParams := store.GetFeeReductionForDateParams{
-		ClientID:     int32(clientId),
+		ClientID:     clientId,
 		Datereceived: invoice.Raiseddate,
 	}
 
@@ -106,17 +132,20 @@ func (s *Service) AddManualInvoice(ctx context.Context, clientId int, data share
 			amount:             reduction,
 			transactionType:    shared.ParseFeeReductionType(feeReduction.Type),
 			feeReductionId:     feeReduction.ID,
-			clientId:           int32(clientId),
+			clientId:           clientId,
 			invoiceId:          invoice.ID,
 			outstandingBalance: invoice.Amount,
 		})
-		ledgerId, err := tx.CreateLedger(ctx, ledger)
+		id, err := tx.CreateLedger(ctx, ledger)
 		if err != nil {
 			return err
 		}
 
+		var ledgerID pgtype.Int4
+		_ = store.ToInt4(&ledgerID, id)
+
 		for _, allocation := range allocations {
-			allocation.LedgerID = pgtype.Int4{Int32: ledgerId, Valid: true}
+			allocation.LedgerID = ledgerID
 			err = tx.CreateLedgerAllocation(ctx, allocation)
 			if err != nil {
 				return err
@@ -129,7 +158,7 @@ func (s *Service) AddManualInvoice(ctx context.Context, clientId int, data share
 		return commitErr
 	}
 
-	return s.ReapplyCredit(ctx, int32(clientId))
+	return s.ReapplyCredit(ctx, clientId)
 }
 
 func (s *Service) validateManualInvoice(data shared.AddManualInvoice) apierror.ValidationErrors {

--- a/finance-api/internal/service/add_manual_invoice_test.go
+++ b/finance-api/internal/service/add_manual_invoice_test.go
@@ -14,7 +14,7 @@ import (
 func addManualInvoiceSetup(seeder *testhelpers.Seeder) (*Service, shared.AddManualInvoice) {
 	params := shared.AddManualInvoice{
 		InvoiceType:      shared.InvoiceTypeS2,
-		Amount:           shared.Nillable[int]{Value: 50000, Valid: true},
+		Amount:           shared.Nillable[int32]{Value: 50000, Valid: true},
 		RaisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
 		StartDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2024-04-12"), Valid: true},
 		EndDate:          shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
@@ -285,7 +285,7 @@ func Test_invoiceData(t *testing.T) {
 	tests := []struct {
 		name             string
 		args             shared.AddManualInvoice
-		amount           shared.Nillable[int]
+		amount           shared.Nillable[int32]
 		startDate        shared.Nillable[shared.Date]
 		raisedDate       shared.Nillable[shared.Date]
 		endDate          shared.Nillable[shared.Date]
@@ -295,13 +295,13 @@ func Test_invoiceData(t *testing.T) {
 			name: "AD invoice returns correct values",
 			args: shared.AddManualInvoice{
 				InvoiceType:      shared.InvoiceTypeAD,
-				Amount:           shared.Nillable[int]{},
+				Amount:           shared.Nillable[int32]{},
 				StartDate:        shared.Nillable[shared.Date]{},
 				RaisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2023-04-01"), Valid: true},
 				EndDate:          shared.Nillable[shared.Date]{},
 				SupervisionLevel: shared.Nillable[string]{},
 			},
-			amount:           shared.Nillable[int]{Value: 10000, Valid: true},
+			amount:           shared.Nillable[int32]{Value: 10000, Valid: true},
 			startDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2023-04-01"), Valid: true},
 			raisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2023-04-01"), Valid: true},
 			endDate:          shared.Nillable[shared.Date]{Value: shared.NewDate("2023-04-01"), Valid: true},
@@ -311,13 +311,13 @@ func Test_invoiceData(t *testing.T) {
 			name: "GA invoice returns correct values",
 			args: shared.AddManualInvoice{
 				InvoiceType:      shared.InvoiceTypeGA,
-				Amount:           shared.Nillable[int]{},
+				Amount:           shared.Nillable[int32]{},
 				StartDate:        shared.Nillable[shared.Date]{},
 				RaisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2023-04-01"), Valid: true},
 				EndDate:          shared.Nillable[shared.Date]{},
 				SupervisionLevel: shared.Nillable[string]{},
 			},
-			amount:           shared.Nillable[int]{Value: 20000, Valid: true},
+			amount:           shared.Nillable[int32]{Value: 20000, Valid: true},
 			startDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2023-04-01"), Valid: true},
 			raisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2023-04-01"), Valid: true},
 			endDate:          shared.Nillable[shared.Date]{Value: shared.NewDate("2023-04-01"), Valid: true},
@@ -327,13 +327,13 @@ func Test_invoiceData(t *testing.T) {
 			name: "B2 invoice returns correct values",
 			args: shared.AddManualInvoice{
 				InvoiceType:      shared.InvoiceTypeB2,
-				Amount:           shared.Nillable[int]{Value: 10000, Valid: true},
+				Amount:           shared.Nillable[int32]{Value: 10000, Valid: true},
 				StartDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2033-04-01"), Valid: true},
 				RaisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
 				EndDate:          shared.Nillable[shared.Date]{},
 				SupervisionLevel: shared.Nillable[string]{},
 			},
-			amount:           shared.Nillable[int]{Value: 10000, Valid: true},
+			amount:           shared.Nillable[int32]{Value: 10000, Valid: true},
 			startDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2033-04-01"), Valid: true},
 			raisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
 			endDate:          shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
@@ -343,13 +343,13 @@ func Test_invoiceData(t *testing.T) {
 			name: "B3 invoice returns correct values",
 			args: shared.AddManualInvoice{
 				InvoiceType:      shared.InvoiceTypeB3,
-				Amount:           shared.Nillable[int]{Value: 10000, Valid: true},
+				Amount:           shared.Nillable[int32]{Value: 10000, Valid: true},
 				StartDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2033-04-01"), Valid: true},
 				RaisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
 				EndDate:          shared.Nillable[shared.Date]{},
 				SupervisionLevel: shared.Nillable[string]{Value: "MINIMAL", Valid: true},
 			},
-			amount:           shared.Nillable[int]{Value: 10000, Valid: true},
+			amount:           shared.Nillable[int32]{Value: 10000, Valid: true},
 			startDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2033-04-01"), Valid: true},
 			raisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
 			endDate:          shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
@@ -359,13 +359,13 @@ func Test_invoiceData(t *testing.T) {
 			name: "S2 invoice returns correct values",
 			args: shared.AddManualInvoice{
 				InvoiceType:      shared.InvoiceTypeS2,
-				Amount:           shared.Nillable[int]{Value: 10000, Valid: true},
+				Amount:           shared.Nillable[int32]{Value: 10000, Valid: true},
 				StartDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2033-04-01"), Valid: true},
 				RaisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
 				EndDate:          shared.Nillable[shared.Date]{},
 				SupervisionLevel: shared.Nillable[string]{},
 			},
-			amount:           shared.Nillable[int]{Value: 10000, Valid: true},
+			amount:           shared.Nillable[int32]{Value: 10000, Valid: true},
 			startDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2033-04-01"), Valid: true},
 			raisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
 			endDate:          shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
@@ -375,13 +375,13 @@ func Test_invoiceData(t *testing.T) {
 			name: "S3 invoice returns correct values",
 			args: shared.AddManualInvoice{
 				InvoiceType:      shared.InvoiceTypeS3,
-				Amount:           shared.Nillable[int]{Value: 10000, Valid: true},
+				Amount:           shared.Nillable[int32]{Value: 10000, Valid: true},
 				StartDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2033-04-01"), Valid: true},
 				RaisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
 				EndDate:          shared.Nillable[shared.Date]{},
 				SupervisionLevel: shared.Nillable[string]{Value: "MINIMAL", Valid: true},
 			},
-			amount:           shared.Nillable[int]{Value: 10000, Valid: true},
+			amount:           shared.Nillable[int32]{Value: 10000, Valid: true},
 			startDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2033-04-01"), Valid: true},
 			raisedDate:       shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
 			endDate:          shared.Nillable[shared.Date]{Value: shared.NewDate("2025-03-31"), Valid: true},
@@ -391,13 +391,13 @@ func Test_invoiceData(t *testing.T) {
 			name: "No year will return correct values",
 			args: shared.AddManualInvoice{
 				InvoiceType:      shared.InvoiceTypeS3,
-				Amount:           shared.Nillable[int]{Value: 10000, Valid: true},
+				Amount:           shared.Nillable[int32]{Value: 10000, Valid: true},
 				StartDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2033-04-01"), Valid: true},
 				RaisedDate:       shared.Nillable[shared.Date]{},
 				EndDate:          shared.Nillable[shared.Date]{},
 				SupervisionLevel: shared.Nillable[string]{},
 			},
-			amount:           shared.Nillable[int]{Value: 10000, Valid: true},
+			amount:           shared.Nillable[int32]{Value: 10000, Valid: true},
 			startDate:        shared.Nillable[shared.Date]{Value: shared.NewDate("2033-04-01"), Valid: true},
 			raisedDate:       shared.Nillable[shared.Date]{},
 			endDate:          shared.Nillable[shared.Date]{},

--- a/finance-api/internal/service/billing_history_test.go
+++ b/finance-api/internal/service/billing_history_test.go
@@ -35,7 +35,7 @@ func (suite *IntegrationSuite) TestService_GetBillingHistory() {
 
 	tests := []struct {
 		name    string
-		id      int
+		id      int32
 		want    []shared.BillingHistory
 		wantErr bool
 	}{
@@ -507,7 +507,7 @@ func Test_processLedgerAllocations(t *testing.T) {
 	tests := []struct {
 		name        string
 		allocations []store.GetLedgerAllocationsForClientRow
-		clientID    int
+		clientID    int32
 		want        []historyHolder
 	}{
 		{

--- a/finance-api/internal/service/cancel_fee_reduction.go
+++ b/finance-api/internal/service/cancel_fee_reduction.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/auth"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/store"
@@ -15,19 +14,14 @@ func (s *Service) CancelFeeReduction(ctx context.Context, id int32, cancelledFee
 		cancellationReason pgtype.Text
 	)
 
-	e := store.ToInt4(&cancelledBy, ctx.(auth.Context).User.ID)
-	e = cancellationReason.Scan(cancelledFeeReduction.CancellationReason)
-	if e != nil {
-		return e
-	}
+	_ = store.ToInt4(&cancelledBy, ctx.(auth.Context).User.ID)
+	_ = cancellationReason.Scan(cancelledFeeReduction.CancellationReason)
 
-	x, err := s.store.CancelFeeReduction(ctx, store.CancelFeeReductionParams{
+	_, err := s.store.CancelFeeReduction(ctx, store.CancelFeeReductionParams{
 		ID:                 id,
 		CancelledBy:        cancelledBy,
 		CancellationReason: cancellationReason,
 	})
-
-	fmt.Sprint(x)
 
 	if err != nil {
 		return err

--- a/finance-api/internal/service/cancel_fee_reduction.go
+++ b/finance-api/internal/service/cancel_fee_reduction.go
@@ -2,18 +2,32 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/auth"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/store"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 )
 
-func (s *Service) CancelFeeReduction(ctx context.Context, id int, cancelledFeeReduction shared.CancelFeeReduction) error {
-	_, err := s.store.CancelFeeReduction(ctx, store.CancelFeeReductionParams{
-		ID:                 int32(id),
-		CancelledBy:        pgtype.Int4{Int32: int32(ctx.(auth.Context).User.ID), Valid: true},
-		CancellationReason: pgtype.Text{String: cancelledFeeReduction.CancellationReason, Valid: true},
+func (s *Service) CancelFeeReduction(ctx context.Context, id int32, cancelledFeeReduction shared.CancelFeeReduction) error {
+	var (
+		cancelledBy        pgtype.Int4
+		cancellationReason pgtype.Text
+	)
+
+	e := store.ToInt4(&cancelledBy, ctx.(auth.Context).User.ID)
+	e = cancellationReason.Scan(cancelledFeeReduction.CancellationReason)
+	if e != nil {
+		return e
+	}
+
+	x, err := s.store.CancelFeeReduction(ctx, store.CancelFeeReductionParams{
+		ID:                 id,
+		CancelledBy:        cancelledBy,
+		CancellationReason: cancellationReason,
 	})
+
+	fmt.Sprint(x)
 
 	if err != nil {
 		return err

--- a/finance-api/internal/service/fee_reductions.go
+++ b/finance-api/internal/service/fee_reductions.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-func (s *Service) GetFeeReductions(ctx context.Context, id int) (*shared.FeeReductions, error) {
-	feeReductionsRawData, err := s.store.GetFeeReductions(ctx, int32(id))
+func (s *Service) GetFeeReductions(ctx context.Context, id int32) (*shared.FeeReductions, error) {
+	feeReductionsRawData, err := s.store.GetFeeReductions(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/finance-api/internal/service/fee_reductions_test.go
+++ b/finance-api/internal/service/fee_reductions_test.go
@@ -22,7 +22,7 @@ func (suite *IntegrationSuite) TestService_GetFeeReductions() {
 
 	tests := []struct {
 		name    string
-		id      int
+		id      int32
 		want    *shared.FeeReductions
 		wantErr bool
 	}{

--- a/finance-api/internal/service/finance_clients_test.go
+++ b/finance-api/internal/service/finance_clients_test.go
@@ -31,7 +31,7 @@ func (suite *IntegrationSuite) TestService_GetAccountInformation() {
 	Store := store.New(seeder)
 	tests := []struct {
 		name    string
-		id      int
+		id      int32
 		want    *shared.AccountInformation
 		wantErr bool
 	}{

--- a/finance-api/internal/service/get_permitted_adjustments.go
+++ b/finance-api/internal/service/get_permitted_adjustments.go
@@ -5,8 +5,8 @@ import (
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 )
 
-func (s *Service) GetPermittedAdjustments(ctx context.Context, invoiceId int) ([]shared.AdjustmentType, error) {
-	balance, err := s.store.GetInvoiceBalanceDetails(ctx, int32(invoiceId))
+func (s *Service) GetPermittedAdjustments(ctx context.Context, invoiceId int32) ([]shared.AdjustmentType, error) {
+	balance, err := s.store.GetInvoiceBalanceDetails(ctx, invoiceId)
 	if err != nil {
 		return nil, err
 	}

--- a/finance-api/internal/service/get_permitted_adjustments_test.go
+++ b/finance-api/internal/service/get_permitted_adjustments_test.go
@@ -40,7 +40,7 @@ func (suite *IntegrationSuite) TestService_GetPermittedAdjustments() {
 	Store := store.New(seeder.Conn)
 	tests := []struct {
 		name    string
-		id      int
+		id      int32
 		want    []shared.AdjustmentType
 		wantErr bool
 	}{

--- a/finance-api/internal/service/invoice_adjustments.go
+++ b/finance-api/internal/service/invoice_adjustments.go
@@ -5,10 +5,10 @@ import (
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 )
 
-func (s *Service) GetInvoiceAdjustments(ctx context.Context, clientId int) (*shared.InvoiceAdjustments, error) {
+func (s *Service) GetInvoiceAdjustments(ctx context.Context, clientId int32) (*shared.InvoiceAdjustments, error) {
 	var adjustments shared.InvoiceAdjustments
 
-	data, err := s.store.GetInvoiceAdjustments(ctx, int32(clientId))
+	data, err := s.store.GetInvoiceAdjustments(ctx, clientId)
 	if err != nil {
 		return nil, err
 	}

--- a/finance-api/internal/service/invoice_adjustments_test.go
+++ b/finance-api/internal/service/invoice_adjustments_test.go
@@ -30,7 +30,7 @@ func (suite *IntegrationSuite) TestService_GetInvoiceAdjustments() {
 
 	tests := []struct {
 		name    string
-		id      int
+		id      int32
 		want    *shared.InvoiceAdjustments
 		wantErr bool
 	}{

--- a/finance-api/internal/service/invoices.go
+++ b/finance-api/internal/service/invoices.go
@@ -123,8 +123,8 @@ func (ib *invoiceBuilder) addSupervisionLevels(supervisionLevels []store.GetSupe
 	}
 }
 
-func (s *Service) GetInvoices(ctx context.Context, clientId int) (*shared.Invoices, error) {
-	invoices, err := s.store.GetInvoices(ctx, int32(clientId))
+func (s *Service) GetInvoices(ctx context.Context, clientId int32) (*shared.Invoices, error) {
+	invoices, err := s.store.GetInvoices(ctx, clientId)
 	if err != nil {
 		return nil, err
 	}

--- a/finance-api/internal/service/invoices_test.go
+++ b/finance-api/internal/service/invoices_test.go
@@ -33,7 +33,7 @@ func (suite *IntegrationSuite) TestService_GetInvoices() {
 	date, _ := time.Parse("2006-01-02", dateString)
 	tests := []struct {
 		name    string
-		id      int
+		id      int32
 		want    *shared.Invoices
 		wantErr bool
 	}{

--- a/finance-api/internal/service/process_finance_admin_upload_test.go
+++ b/finance-api/internal/service/process_finance_admin_upload_test.go
@@ -75,7 +75,7 @@ func (suite *IntegrationSuite) Test_processFinanceAdminUpload() {
 					Error      string `json:"error"`
 					UploadType string `json:"upload_type"`
 				}{
-					"Unable to download report",
+					"unable to download report",
 					"",
 				},
 			},

--- a/finance-api/internal/service/update_pending_invoice_adjustment.go
+++ b/finance-api/internal/service/update_pending_invoice_adjustment.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 )
 
-func (s *Service) UpdatePendingInvoiceAdjustment(ctx context.Context, clientId int, adjustmentId int, status shared.AdjustmentStatus) error {
+func (s *Service) UpdatePendingInvoiceAdjustment(ctx context.Context, clientId int32, adjustmentId int32, status shared.AdjustmentStatus) error {
 	ctx, cancelTx := s.WithCancel(ctx)
 	defer cancelTx()
 
@@ -17,10 +17,13 @@ func (s *Service) UpdatePendingInvoiceAdjustment(ctx context.Context, clientId i
 		return err
 	}
 
+	var updatedBy pgtype.Int4
+	_ = store.ToInt4(&updatedBy, ctx.(auth.Context).User.ID)
+
 	decisionParams := store.SetAdjustmentDecisionParams{
-		ID:        int32(adjustmentId),
+		ID:        adjustmentId,
 		Status:    status.Key(),
-		UpdatedBy: pgtype.Int4{Int32: int32(ctx.(auth.Context).User.ID), Valid: true},
+		UpdatedBy: updatedBy,
 	}
 
 	adjustment, err := tx.SetAdjustmentDecision(ctx, decisionParams)
@@ -32,12 +35,12 @@ func (s *Service) UpdatePendingInvoiceAdjustment(ctx context.Context, clientId i
 		ledger, allocations := generateLedgerEntries(ctx, addLedgerVars{
 			amount:             adjustment.Amount,
 			transactionType:    shared.ParseAdjustmentType(adjustment.AdjustmentType),
-			clientId:           int32(clientId),
+			clientId:           clientId,
 			invoiceId:          adjustment.InvoiceID,
 			outstandingBalance: adjustment.Outstanding,
 		})
 
-		ledgerId, err := tx.CreateLedgerForAdjustment(ctx, store.CreateLedgerForAdjustmentParams{
+		id, err := tx.CreateLedgerForAdjustment(ctx, store.CreateLedgerForAdjustmentParams{
 			ClientID:       ledger.ClientID,
 			Amount:         ledger.Amount,
 			Notes:          ledger.Notes,
@@ -45,14 +48,17 @@ func (s *Service) UpdatePendingInvoiceAdjustment(ctx context.Context, clientId i
 			Status:         ledger.Status,
 			FeeReductionID: ledger.FeeReductionID,
 			CreatedBy:      ledger.CreatedBy,
-			ID:             int32(adjustmentId),
+			ID:             adjustmentId,
 		})
 		if err != nil {
 			return err
 		}
 
+		var ledgerID pgtype.Int4
+		_ = store.ToInt4(&ledgerID, id)
+
 		for _, allocation := range allocations {
-			allocation.LedgerID = pgtype.Int4{Int32: ledgerId, Valid: true}
+			allocation.LedgerID = ledgerID
 			err = tx.CreateLedgerAllocation(ctx, allocation)
 			if err != nil {
 				return err
@@ -66,7 +72,7 @@ func (s *Service) UpdatePendingInvoiceAdjustment(ctx context.Context, clientId i
 	}
 
 	if status == shared.AdjustmentStatusApproved {
-		return s.ReapplyCredit(ctx, int32(clientId))
+		return s.ReapplyCredit(ctx, clientId)
 	}
 	return nil
 }

--- a/finance-api/internal/service/update_pending_invoice_adjustment_test.go
+++ b/finance-api/internal/service/update_pending_invoice_adjustment_test.go
@@ -41,14 +41,14 @@ func (suite *IntegrationSuite) TestService_UpdatePendingInvoiceAdjustment() {
 	s := NewService(seeder.Conn, dispatch, nil, nil, nil)
 
 	type args struct {
-		clientId     int
-		adjustmentId int
+		clientId     int32
+		adjustmentId int32
 		status       shared.AdjustmentStatus
 	}
 	tests := []struct {
 		name                       string
 		args                       args
-		invoiceId                  int
+		invoiceId                  int32
 		expectedAllocationStatuses []string
 	}{
 		{

--- a/finance-api/internal/store/invoices.sql.go
+++ b/finance-api/internal/store/invoices.sql.go
@@ -122,7 +122,7 @@ func (q *Queries) GetInvoiceBalanceDetails(ctx context.Context, id int32) (GetIn
 const getInvoiceBalancesForFeeReductionRange = `-- name: GetInvoiceBalancesForFeeReductionRange :many
 SELECT i.id,
        i.amount,
-       COALESCE(general_fee.amount, 0)               general_supervision_fee,
+       COALESCE(general_fee.amount, 0)::INT          general_supervision_fee,
        i.amount - COALESCE(transactions.received, 0) outstanding,
        i.feetype
 FROM invoice i
@@ -148,7 +148,7 @@ WHERE i.raiseddate >= (fr.datereceived - INTERVAL '6 months')
 type GetInvoiceBalancesForFeeReductionRangeRow struct {
 	ID                    int32
 	Amount                int32
-	GeneralSupervisionFee int64
+	GeneralSupervisionFee int32
 	Outstanding           int32
 	Feetype               string
 }

--- a/finance-api/internal/store/queries/invoices.sql
+++ b/finance-api/internal/store/queries/invoices.sql
@@ -95,7 +95,7 @@ WHERE i.id = $1;
 -- name: GetInvoiceBalancesForFeeReductionRange :many
 SELECT i.id,
        i.amount,
-       COALESCE(general_fee.amount, 0)               general_supervision_fee,
+       COALESCE(general_fee.amount, 0)::INT          general_supervision_fee,
        i.amount - COALESCE(transactions.received, 0) outstanding,
        i.feetype
 FROM invoice i

--- a/finance-api/internal/store/type_conv.go
+++ b/finance-api/internal/store/type_conv.go
@@ -7,30 +7,21 @@ import (
 )
 
 func ToInt4(dest *pgtype.Int4, i any) error {
-	switch i.(type) {
+	switch i := i.(type) {
 	case int:
-		v := i.(int)
-		if v < math.MinInt32 || v > math.MaxInt32 {
+		if i < math.MinInt32 || i > math.MaxInt32 {
 			return fmt.Errorf("cannot scan %T", i)
 		}
-		dest.Int32 = int32(v)
+		dest.Int32 = int32(i)
 		dest.Valid = true
 	case int32:
-		v := i.(int32)
-		if v < 0 {
+		if i < 0 {
 			return fmt.Errorf("cannot scan %T", i)
 		}
-		dest.Int32 = v
+		dest.Int32 = i
 		dest.Valid = true
 	default:
 		return dest.Scan(i)
 	}
 	return nil
-}
-
-func toInt32(i int) (int32, error) {
-	if i < math.MinInt32 || i > math.MaxInt32 {
-		return 0, fmt.Errorf("cannot scan %T", i)
-	}
-	return int32(i), nil
 }

--- a/finance-api/internal/store/type_conv.go
+++ b/finance-api/internal/store/type_conv.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"fmt"
+	"github.com/jackc/pgx/v5/pgtype"
+	"math"
+)
+
+func ToInt4(dest *pgtype.Int4, i any) error {
+	switch i.(type) {
+	case int:
+		v := i.(int)
+		if v < math.MinInt32 || v > math.MaxInt32 {
+			return fmt.Errorf("cannot scan %T", i)
+		}
+		dest.Int32 = int32(v)
+		dest.Valid = true
+	case int32:
+		v := i.(int32)
+		if v < 0 {
+			return fmt.Errorf("cannot scan %T", i)
+		}
+		dest.Int32 = v
+		dest.Valid = true
+	default:
+		return dest.Scan(i)
+	}
+	return nil
+}
+
+func toInt32(i int) (int32, error) {
+	if i < math.MinInt32 || i > math.MaxInt32 {
+		return 0, fmt.Errorf("cannot scan %T", i)
+	}
+	return int32(i), nil
+}

--- a/finance-api/internal/testhelpers/seeder.go
+++ b/finance-api/internal/testhelpers/seeder.go
@@ -12,10 +12,10 @@ import (
 )
 
 type Service interface {
-	AddManualInvoice(ctx context.Context, clientID int, invoice shared.AddManualInvoice) error
-	AddInvoiceAdjustment(ctx context.Context, clientID int, invoiceId int, adjustment *shared.AddInvoiceAdjustmentRequest) (*shared.InvoiceReference, error)
-	UpdatePendingInvoiceAdjustment(ctx context.Context, clientID int, adjustmentId int, status shared.AdjustmentStatus) error
-	AddFeeReduction(ctx context.Context, clientId int, reduction shared.AddFeeReduction) error
+	AddManualInvoice(ctx context.Context, clientID int32, invoice shared.AddManualInvoice) error
+	AddInvoiceAdjustment(ctx context.Context, clientID int32, invoiceId int32, adjustment *shared.AddInvoiceAdjustmentRequest) (*shared.InvoiceReference, error)
+	UpdatePendingInvoiceAdjustment(ctx context.Context, clientID int32, adjustmentId int32, status shared.AdjustmentStatus) error
+	AddFeeReduction(ctx context.Context, clientId int32, reduction shared.AddFeeReduction) error
 	ProcessPaymentsUploadLine(ctx context.Context, tx *store.Tx, details shared.PaymentDetails, index int, failedLines *map[int]string) error
 	BeginStoreTx(ctx context.Context) (*store.Tx, error)
 }

--- a/finance-api/internal/validation/validation.go
+++ b/finance-api/internal/validation/validation.go
@@ -108,6 +108,12 @@ func validateIntGreaterThan(fl validator.FieldLevel) bool {
 			panic(err)
 		}
 		return !v.Valid || v.Value > intParam
+	} else if v, ok := fl.Field().Interface().(shared.Nillable[int32]); ok {
+		intParam, err := strconv.ParseInt(fl.Param(), 10, 32)
+		if err != nil {
+			panic(err)
+		}
+		return !v.Valid || v.Value > int32(intParam)
 	}
 	return false
 }
@@ -119,6 +125,12 @@ func validateIntLessThanOrEqualTo(fl validator.FieldLevel) bool {
 			panic(err)
 		}
 		return !v.Valid || v.Value <= intParam
+	} else if v, ok := fl.Field().Interface().(shared.Nillable[int32]); ok {
+		intParam, err := strconv.ParseInt(fl.Param(), 10, 32)
+		if err != nil {
+			panic(err)
+		}
+		return !v.Valid || v.Value <= int32(intParam)
 	}
 	return false
 }

--- a/finance-api/main.go
+++ b/finance-api/main.go
@@ -205,8 +205,9 @@ func run(ctx context.Context, logger *slog.Logger) error {
 		})
 
 	s := &http.Server{
-		Addr:    ":" + envs.port,
-		Handler: server.SetupRoutes(logger),
+		Addr:              ":" + envs.port,
+		Handler:           server.SetupRoutes(logger),
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {

--- a/finance-hub/internal/api/cache.go
+++ b/finance-hub/internal/api/cache.go
@@ -48,6 +48,6 @@ func (c Caches) getAndSetPlaceholder(id int) *shared.User {
 
 func (c Caches) updateUsers(users []shared.User) {
 	for _, user := range users {
-		_ = c.users.Add(strconv.Itoa(user.ID), &user, defaultExpiration)
+		_ = c.users.Add(strconv.Itoa(int(user.ID)), &user, defaultExpiration)
 	}
 }

--- a/finance-hub/internal/auth/jwt.go
+++ b/finance-hub/internal/auth/jwt.go
@@ -26,10 +26,10 @@ func (j *JWT) CreateJWT(ctx context.Context) string {
 	claims := &Claims{
 		Roles: user.Roles,
 		RegisteredClaims: jwt.RegisteredClaims{
-			ID:        strconv.Itoa(user.ID),
+			ID:        strconv.Itoa(int(user.ID)),
 			Issuer:    "urn:opg:payments-hub",
 			Audience:  jwt.ClaimStrings{"urn:opg:payments-api"},
-			Subject:   "urn:opg:sirius:users:" + strconv.Itoa(user.ID),
+			Subject:   "urn:opg:sirius:users:" + strconv.Itoa(int(user.ID)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 			ExpiresAt: jwt.NewNumericDate(exp),
 		},

--- a/finance-hub/main.go
+++ b/finance-hub/main.go
@@ -121,6 +121,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 			BackendURL:      envs.backendURL,
 			BillingTeamID:   envs.billingTeamID,
 		}),
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {
@@ -176,7 +177,7 @@ func createTemplates(envVars *Envs) map[string]*template.Template {
 		},
 	}
 
-	templateDirPath := envVars.webDir + "/template"
+	templateDirPath := filepath.Clean(envVars.webDir + "/template")
 	templateDir, _ := os.Open(templateDirPath)
 	templateDirs, _ := templateDir.Readdir(0)
 	_ = templateDir.Close()

--- a/shared/add_manual_invoice.go
+++ b/shared/add_manual_invoice.go
@@ -2,7 +2,7 @@ package shared
 
 type AddManualInvoice struct {
 	InvoiceType      InvoiceType      `json:"invoiceType" validate:"required,valid-enum"`
-	Amount           Nillable[int]    `json:"amount" validate:"nillable-int-gt=50,nillable-int-lte=32000"`
+	Amount           Nillable[int32]  `json:"amount" validate:"nillable-int-gt=50,nillable-int-lte=32000"`
 	RaisedDate       Nillable[Date]   `json:"raisedDate" validate:"nillable-date-required"`
 	StartDate        Nillable[Date]   `json:"startDate" validate:"nillable-date-required"`
 	EndDate          Nillable[Date]   `json:"endDate" validate:"nillable-date-required"`

--- a/shared/event.go
+++ b/shared/event.go
@@ -61,11 +61,11 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 }
 
 type DebtPositionChangedEvent struct {
-	ClientID int `json:"clientId"`
+	ClientID int32 `json:"clientId"`
 }
 
 type ClientCreatedEvent struct {
-	ClientID int    `json:"clientId"`
+	ClientID int32  `json:"clientId"`
 	CourtRef string `json:"courtRef"`
 }
 

--- a/shared/ledger_entry.go
+++ b/shared/ledger_entry.go
@@ -3,5 +3,5 @@ package shared
 type AddInvoiceAdjustmentRequest struct {
 	AdjustmentType  AdjustmentType `json:"adjustmentType" validate:"valid-enum"`
 	AdjustmentNotes string         `json:"notes" validate:"required,thousand-character-limit"`
-	Amount          int            `json:"amount,omitempty" validate:"required_if=AdjustmentType 2,required_if=AdjustmentType 3,omitempty,gt=0"`
+	Amount          int32          `json:"amount,omitempty" validate:"required_if=AdjustmentType 2,required_if=AdjustmentType 3,omitempty,gt=0"`
 }

--- a/shared/nillable.go
+++ b/shared/nillable.go
@@ -27,10 +27,10 @@ func TransformNillableString(stringPointer *string) Nillable[string] {
 	return transformedNillable
 }
 
-func TransformNillableInt(stringPointer *string) Nillable[int] {
-	var transformedNillableInt Nillable[int]
+func TransformNillableInt(stringPointer *string) Nillable[int32] {
+	var transformedNillableInt Nillable[int32]
 	if stringPointer != nil {
-		transformedNillableInt = Nillable[int]{
+		transformedNillableInt = Nillable[int32]{
 			Value: DecimalStringToInt(*stringPointer),
 			Valid: true,
 		}

--- a/shared/transform.go
+++ b/shared/transform.go
@@ -16,6 +16,6 @@ func IntToDecimalString(i int) string {
 }
 
 func DecimalStringToInt(s string) int32 {
-	i, _ := strconv.ParseFloat(s, 32)
-	return int32(i * 100)
+	f, _ := strconv.ParseFloat(s, 64)
+	return int32(f * 100)
 }

--- a/shared/transform.go
+++ b/shared/transform.go
@@ -15,7 +15,7 @@ func IntToDecimalString(i int) string {
 	return s
 }
 
-func DecimalStringToInt(s string) int {
-	i, _ := strconv.ParseFloat(s, 64)
-	return int(i * 100)
+func DecimalStringToInt(s string) int32 {
+	i, _ := strconv.ParseFloat(s, 32)
+	return int32(i * 100)
 }

--- a/shared/transform_test.go
+++ b/shared/transform_test.go
@@ -43,7 +43,7 @@ func TestDecimalStringToInt(t *testing.T) {
 	tests := []struct {
 		name string
 		arg  string
-		want int
+		want int32
 	}{
 		{
 			"converts two decimal places to string",

--- a/shared/user.go
+++ b/shared/user.go
@@ -1,7 +1,7 @@
 package shared
 
 type User struct {
-	ID          int      `json:"id"`
+	ID          int32    `json:"id"`
 	DisplayName string   `json:"displayName"`
 	Roles       []string `json:"roles"`
 }


### PR DESCRIPTION
Changes:
* Helper function to safely parse path params to 32 bit ints.
* Helper function to safety coerce ints to int4 for database IDs.
* Switched to using scanner functions to scan values into pgtype types. This means we no longer need to remember to set whether a value is valid or not.
* Switched to using int32 as the default parameter for backend functions (for IDs at least) to mean less conversion is necessary.
* Updated filepath sanitation.
* Adds header read timeout, as Go server doesn't have one by default. Set to 10s but we can change this if needed.