### PR TITLE
adds defer closes and timeout to context to try and avoid OOM issues

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,7 +1,6 @@
-# Temp ignore Vulns in Goose Std Lib Package until this month's release
-CVE-2024-45336
-CVE-2024-45341
-CVE-2025-22866
-
-# Temp Ignore Goose x/net Vuln
-CVE-2025-22870
+# Temp ignore Vulns in Goose until fixed
+CVE-2024-45336 - stdlib
+CVE-2024-45341 - stdlib
+CVE-2025-22866 - stdlib
+CVE-2025-22870 - golang.org/x/net
+CVE-2025-30204 - github.com/golang-jwt/jwt/v4

--- a/finance-api/cmd/api/request_report.go
+++ b/finance-api/cmd/api/request_report.go
@@ -41,10 +41,15 @@ func (s *Server) requestReport(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	go func(logger *slog.Logger) {
+		// context cancels after 2 minutes to prevent the request from hanging
+		tctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
 		ctx := telemetry.ContextWithLogger(auth.Context{
-			Context: context.Background(),
+			Context: tctx,
 			User:    r.Context().(auth.Context).User,
 		}, logger)
+
 		s.reports.GenerateAndUploadReport(ctx, reportRequest, time.Now())
 	}(telemetry.LoggerFromContext(r.Context()))
 

--- a/finance-api/internal/db/client.go
+++ b/finance-api/internal/db/client.go
@@ -38,6 +38,8 @@ func (c *Client) Run(ctx context.Context, query ReportQuery) ([][]string, error)
 		return nil, err
 	}
 
+	defer rows.Close()
+
 	stringRows, err := pgx.CollectRows[[]string](rows, rowToStringMap)
 	if err != nil {
 		return nil, err

--- a/finance-api/internal/filestorage/client.go
+++ b/finance-api/internal/filestorage/client.go
@@ -61,6 +61,9 @@ func (c *Client) GetFile(ctx context.Context, bucketName string, fileName string
 	if err != nil {
 		return nil, err
 	}
+
+	defer output.Body.Close()
+
 	return output.Body, nil
 }
 


### PR DESCRIPTION
We were missing some closing calls on data access and this potentially is not freeing up memory, as it is then down to the garbage collector to clean up. My suspicion is the query result set was never getting fully read for some reason and this led to data continuously streaming until it ran out of memory. I could be completely wrong but there is some suggestion of this occurring elsewhere from crawling through Github issues for the library we use. 

I've also added a timeout to the context, so if a query is taking to long, it will automatically cancel and clean up resources. I've set this at 2 minutes as I think even our longest running query is comfortably within that.