### PR TITLE
pfs-336: Excludes 'Format String Error' Zap alert. The application on…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ cypress/videos
 cypress/downloads
 /cypress/cypress/
 
+# Zap reports
+zap/FinanceHubReport/
+zap/FinanceHubReport.*
+
 # binaries
 /main
 

--- a/zap/scan.sh
+++ b/zap/scan.sh
@@ -84,8 +84,9 @@ filter_false_positives() {
     # This will globally report all alert results of this type as a false positive and exclude them from the reports
     # These Alert ID's can be found by viewing the ids of the /JSON/pscan/view/scanners/ and /JSON/ascan/view/scanners/ endpoints
     ALERTS=(
-        "10031", # User Controllable HTML Element Attribute (Potential XSS)
-        "6" # Path Traversal
+        "10031" # User Controllable HTML Element Attribute (Potential XSS)
+        "6"     # Path Traversal
+        "30002" # Format String Error
     )
     for ALERT in "${ALERTS[@]}"
     do


### PR DESCRIPTION
…ly produces query strings, it doesn't consume them.