### PR TITLE
SFS-53 Create failed DD schedule task

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To seed this data, add the inserts to `/test-data.sql`.
 `make test`
 
 ## Run the Cypress tests
+`make build-all`
 `make cypress`
 
 Or to run interactively:

--- a/api-mocks/allpay/allpay-config.yml
+++ b/api-mocks/allpay/allpay-config.yml
@@ -25,7 +25,7 @@ resources:
     method: post
     requestBody:
       jsonPath: $.LastName
-      value: allpay_schedule_fail
+      value: allpay_mandate_fail
       operator: contains
     response:
       statusCode: 400

--- a/api-mocks/allpay/allpay-config.yml
+++ b/api-mocks/allpay/allpay-config.yml
@@ -15,21 +15,21 @@ resources:
     method: post
     requestBody:
       jsonPath: $.LastName
-      value: allpay_mandate_validation
+      value: allpay_mandate_fail
       operator: contains
     response:
       statusCode: 422
       file: data/validation.json
 
-  - path: "/AllpayApi/Customers/{SchemeCode}/{ClientRef}/{Surname}/VariableMandates"
+  - path: "/AllpayApi/Customers/{SchemeCode}/VariableMandates/Create"
     method: post
     requestBody:
       jsonPath: $.LastName
-        value: allpay_mandate_fail
-        operator: contains
-      response:
-        statusCode: 400
-        content: "Bad Request - Please check the format of your body request"
+      value: allpay_mandate_validation
+      operator: contains
+    response:
+      statusCode: 400
+      content: "Bad Request - Please check the format of your body request"
 
   - path: "/AllpayApi/Customers/{SchemeCode}/{ClientRef}/{Surname}/VariableMandates"
     method: post
@@ -41,7 +41,7 @@ resources:
     method: post
     requestBody:
       jsonPath: $.LastName
-      value: allpay_schedule_validation
+      value: allpay_schedule_fail
       operator: contains
     response:
       statusCode: 422
@@ -51,7 +51,7 @@ resources:
     method: post
     requestBody:
       jsonPath: $.LastName
-      value: allpay_schedule_fail
+      value: allpay_schedule_validation
       operator: contains
     response:
       statusCode: 400

--- a/api-mocks/allpay/allpay-config.yml
+++ b/api-mocks/allpay/allpay-config.yml
@@ -39,20 +39,16 @@ resources:
 
   - path: "/AllpayApi/Customers/{SchemeCode}/{ClientRef}/{Surname}/VariableMandates"
     method: post
-    requestBody:
-      jsonPath: $.LastName
-      value: allpay_schedule_validation
-      operator: contains
+    pathParams:
+       Surname: allpay_schedule_validation
     response:
       statusCode: 422
       file: data/validation.json
 
   - path: "/AllpayApi/Customers/{SchemeCode}/{ClientRef}/{Surname}/VariableMandates"
     method: post
-    requestBody:
-      jsonPath: $.LastName
-      value: allpay_schedule_fail
-      operator: contains
+    pathParams:
+      Surname: allpay_schedule_fail
     response:
       statusCode: 400
       content: "Bad Request - Please check the format of your body request"

--- a/api-mocks/allpay/allpay-config.yml
+++ b/api-mocks/allpay/allpay-config.yml
@@ -21,15 +21,15 @@ resources:
       statusCode: 422
       file: data/validation.json
 
-  - path: "/AllpayApi/Customers/{SchemeCode}/VariableMandates/Create"
+  - path: "/AllpayApi/Customers/{SchemeCode}/{ClientRef}/{Surname}/VariableMandates"
     method: post
     requestBody:
       jsonPath: $.LastName
-      value: allpay_mandate_fail
-      operator: contains
-    response:
-      statusCode: 400
-      content: "Bad Request - Please check the format of your body request"
+        value: allpay_mandate_fail
+        operator: contains
+      response:
+        statusCode: 400
+        content: "Bad Request - Please check the format of your body request"
 
   - path: "/AllpayApi/Customers/{SchemeCode}/{ClientRef}/{Surname}/VariableMandates"
     method: post
@@ -41,7 +41,7 @@ resources:
     method: post
     requestBody:
       jsonPath: $.LastName
-      value: allpay_schedule_fail
+      value: allpay_schedule_validation
       operator: contains
     response:
       statusCode: 422

--- a/cypress/e2e/refund-decision.cy.js
+++ b/cypress/e2e/refund-decision.cy.js
@@ -27,7 +27,7 @@ describe("Refunds tab", () => {
         cy.visit("/clients/18/refunds");
 
         cy.get("table#refunds > tbody")
-            .contains("Cancel me").parent("tr").as("cancelRow");
+            .contains("Cancel me 1").parent("tr").as("cancelRow");
 
         cy.get("@cancelRow")
             .find(".form-button-menu")
@@ -41,7 +41,7 @@ describe("Refunds tab", () => {
         cy.visit("/clients/24/refunds");
 
         cy.get("table#refunds > tbody")
-            .contains("Cancel me").parent("tr").as("cancelRow");
+            .contains("Cancel me 2").parent("tr").as("cancelRow");
 
         cy.get("@cancelRow")
             .find(".form-button-menu")

--- a/finance-api/cmd/api/create_dd_mandate.go
+++ b/finance-api/cmd/api/create_dd_mandate.go
@@ -36,7 +36,7 @@ func (s *Server) createDirectDebitMandate(w http.ResponseWriter, r *http.Request
 
 	if err := s.service.CreateDirectDebitSchedule(ctx, clientId, shared.CreateSchedule{AllPayCustomer: createMandate.AllPayCustomer}); err != nil {
 		logger.Error("creating schedule in createDirectDebitMandate failed", "err", err)
-		return err
+		// Confirmed with business they do not want an error message returned even if the schedule fails
 	}
 
 	w.WriteHeader(http.StatusCreated)

--- a/finance-api/internal/db/suite_test.go
+++ b/finance-api/internal/db/suite_test.go
@@ -32,6 +32,9 @@ func (m *mockDispatch) CreditOnAccount(ctx context.Context, event event.CreditOn
 func (m *mockDispatch) RefundAdded(ctx context.Context, event event.RefundAdded) error {
 	return nil
 }
+func (m *mockDispatch) DirectDebitScheduleFailed(ctx context.Context, event event.DirectDebitScheduleFailed) error {
+	return nil
+}
 
 func (suite *IntegrationSuite) SetupSuite() {
 	suite.ctx = auth.Context{

--- a/finance-api/internal/event/direct_debit_schedule_failed.go
+++ b/finance-api/internal/event/direct_debit_schedule_failed.go
@@ -1,0 +1,13 @@
+package event
+
+import (
+	"context"
+)
+
+type DirectDebitScheduleFailed struct {
+	ClientID int `json:"clientId"`
+}
+
+func (c *Client) DirectDebitScheduleFailed(ctx context.Context, event DirectDebitScheduleFailed) error {
+	return c.send(ctx, "direct-debit-schedule-failed", event)
+}

--- a/finance-api/internal/service/create_dd_schedule.go
+++ b/finance-api/internal/service/create_dd_schedule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/apierror"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/event"
 	"time"
 
@@ -76,7 +77,7 @@ func (s *Service) CreateDirectDebitSchedule(ctx context.Context, clientID int32,
 		if dispatchErr != nil {
 			return dispatchErr
 		}
-		return err
+		return apierror.BadRequestError("Allpay", "Failed", err)
 	}
 	return tx.Commit(ctx)
 }

--- a/finance-api/internal/service/create_dd_schedule.go
+++ b/finance-api/internal/service/create_dd_schedule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/event"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -68,6 +69,12 @@ func (s *Service) CreateDirectDebitSchedule(ctx context.Context, clientID int32,
 			// we validate in advance so validation errors from AllPay should never occur
 			// if they do, log them so we can investigate
 			logger.Error("validation errors returned from allpay", "errors", ve.Messages)
+		}
+		dispatchErr := s.dispatch.DirectDebitScheduleFailed(ctx, event.DirectDebitScheduleFailed{
+			ClientID: int(clientID),
+		})
+		if dispatchErr != nil {
+			return dispatchErr
 		}
 		return err
 	}

--- a/finance-api/internal/service/create_dd_schedule_test.go
+++ b/finance-api/internal/service/create_dd_schedule_test.go
@@ -160,7 +160,8 @@ func (suite *IntegrationSuite) TestService_CreateDirectDebitSchedule_createSched
 	collectionDate, _ := time.Parse("2006-01-02", "2022-04-02")
 	allpayMock := &mockAllpay{errs: map[string]error{"CreateSchedule": errors.New("CreateSchedule error")}}
 	govUKMock := &mockGovUK{nextWorkingDay: collectionDate}
-	s := Service{store: store.New(seeder.Conn), allpay: allpayMock, govUK: govUKMock, tx: seeder.Conn}
+	dispatchMock := &mockDispatch{}
+	s := Service{store: store.New(seeder.Conn), allpay: allpayMock, govUK: govUKMock, tx: seeder.Conn, dispatch: dispatchMock}
 
 	err := s.CreateDirectDebitSchedule(ctx, 11, shared.CreateSchedule{
 		AllPayCustomer: shared.AllPayCustomer{

--- a/finance-api/internal/service/service.go
+++ b/finance-api/internal/service/service.go
@@ -23,6 +23,7 @@ type TX interface {
 type Dispatch interface {
 	CreditOnAccount(ctx context.Context, event event.CreditOnAccount) error
 	PaymentMethodChanged(ctx context.Context, event event.PaymentMethod) error
+	DirectDebitScheduleFailed(ctx context.Context, event event.DirectDebitScheduleFailed) error
 	RefundAdded(ctx context.Context, event event.RefundAdded) error
 }
 

--- a/finance-api/internal/service/service_test.go
+++ b/finance-api/internal/service/service_test.go
@@ -75,6 +75,11 @@ func (m *mockDispatch) RefundAdded(ctx context.Context, event event.RefundAdded)
 	return nil
 }
 
+func (m *mockDispatch) DirectDebitScheduleFailed(ctx context.Context, event event.DirectDebitScheduleFailed) error {
+	m.event = event
+	return nil
+}
+
 type mockAllpay struct {
 	called           []string
 	errs             map[string]error

--- a/json-server/config/db.json
+++ b/json-server/config/db.json
@@ -480,6 +480,12 @@
     },
     {
       "id": 24,
+      "firstname": "Annie",
+      "surname": "Approved",
+      "caseRecNumber": "24242400"
+    },
+    {
+      "id": 25,
       "firstname": "Odin",
       "surname": "allpay_mandate_fail",
       "caseRecNumber": "23232333",
@@ -501,7 +507,7 @@
       }
     },
     {
-      "id": 25,
+      "id": 26,
       "firstname": "Marina",
       "surname": "allpay_schedule_fail",
       "caseRecNumber": "23232333",
@@ -523,7 +529,7 @@
       }
     },
     {
-      "id": 26,
+      "id": 27,
       "firstname": "Gomez",
       "surname": "allpay_schedule_validation",
       "caseRecNumber": "23232333",

--- a/json-server/config/db.json
+++ b/json-server/config/db.json
@@ -481,7 +481,7 @@
     {
       "id": 24,
       "firstname": "Odin",
-      "surname": "Direct_allpay_mandate_fail",
+      "surname": "allpay_mandate_fail",
       "caseRecNumber": "23232333",
       "addressLine1": "123 Fake Street",
       "addressLine2": "Mainville",

--- a/json-server/config/db.json
+++ b/json-server/config/db.json
@@ -479,6 +479,28 @@
       }
     },
     {
+      "id": 24,
+      "firstname": "Odin",
+      "surname": "Direct_allpay_mandate_fail",
+      "caseRecNumber": "23232333",
+      "addressLine1": "123 Fake Street",
+      "addressLine2": "Mainville",
+      "town": "Springfield",
+      "postcode": "S1 1FF",
+      "feePayer": {
+        "id": 1,
+        "deputyStatus": "Active"
+      },
+      "activeCaseType": {
+        "handle": "HW",
+        "label": "Health & Welfare"
+      },
+      "clientStatus": {
+        "handle": "ACTIVE",
+        "label": "Active"
+      }
+    },
+    {
       "id": 99,
       "firstname": "Nelly",
       "surname": "Nullman",

--- a/test-data/seed_data.sql
+++ b/test-data/seed_data.sql
@@ -118,7 +118,7 @@ INSERT INTO bank_details VALUES (4, 8, 'Donny Decisions', '12345678', '11-22-33'
 
 -- cancel a processed refund
 INSERT INTO finance_client VALUES (18001, 18, 'cancelrefund', 'DEMANDED', null, '18181818');
-INSERT INTO refund VALUES (9, 18001, '2021-06-01', 12344, 'APPROVED', 'Cancel me', 1, '2022-06-01 00:00:00', 1, '2022-06-06 00:00:00', '2025-06-06 00:00:00');
+INSERT INTO refund VALUES (9, 18001, '2021-06-01', 12344, 'APPROVED', 'Cancel me 1', 1, '2022-06-01 00:00:00', 1, '2022-06-06 00:00:00', '2025-06-06 00:00:00');
 
 -- cancel direct debit
 INSERT INTO finance_client VALUES (19001, 19, 'canceldirectdebit', 'DIRECT DEBIT', null, '19191919');
@@ -157,7 +157,7 @@ INSERT INTO invoice VALUES (20, 26, 23004, 'AD', 'AD2323004/24', '2024-04-01', '
 
 -- cancel an approved refund
 INSERT INTO finance_client VALUES (24001, 24, 'cancelapprovedrefund', 'DEMANDED', null, '24242400');
-INSERT INTO refund VALUES (10, 24001, '2021-06-01', 12344, 'APPROVED', 'Cancel me', 1, '2022-06-01 00:00:00', 1, '2022-06-06 00:00:00')
+INSERT INTO refund VALUES (12, 24001, '2021-06-01', 11122, 'APPROVED', 'Cancel me 2', 2, '2022-06-01 00:00:00', 1, '2022-06-06 00:00:00');
 
 -- TEST CLIENT DATA: Add data for default client here
 

--- a/test-data/seed_data.sql
+++ b/test-data/seed_data.sql
@@ -149,11 +149,15 @@ INSERT INTO invoice VALUES (17, 22, 22001, 'AD', 'AD222200/24', '2024-04-01', '2
 -- failed direct debit allpay validation
 INSERT INTO finance_client VALUES (23001, 23, 'allpayvalidation', 'DIRECT DEBIT', null, '23232300');
 INSERT INTO invoice VALUES (18, 23, 23001, 'AD', 'AD232300/24', '2024-04-01', '2025-03-31', 10000, null, '2025-03-31', 10, '2024-04-01', null, null, null, '2024-04-10T08:36:40+00:00', 99);
+INSERT INTO finance_client VALUES (23003, 25, 'allpayvalidation', 'DIRECT DEBIT', null, '23232301');
+INSERT INTO invoice VALUES (19, 25, 23003, 'AD', 'AD2323003/24', '2024-04-01', '2025-03-31', 10000, null, '2025-03-31', 10, '2024-04-01', null, null, null, '2024-04-10T08:36:40+00:00', 99);
+INSERT INTO finance_client VALUES (23004, 26, 'allpayvalidation', 'DIRECT DEBIT', null, '23232302');
+INSERT INTO invoice VALUES (20, 26, 23004, 'AD', 'AD2323004/24', '2024-04-01', '2025-03-31', 10000, null, '2025-03-31', 10, '2024-04-01', null, null, null, '2024-04-10T08:36:40+00:00', 99);
+
 
 -- cancel an approved refund
 INSERT INTO finance_client VALUES (24001, 24, 'cancelapprovedrefund', 'DEMANDED', null, '24242400');
-INSERT INTO refund VALUES (10, 24001, '2021-06-01', 12344, 'APPROVED', 'Cancel me', 1, '2022-06-01 00:00:00', 1, '2022-06-06 00:00:00');
-
+INSERT INTO refund VALUES (10, 24001, '2021-06-01', 12344, 'APPROVED', 'Cancel me', 1, '2022-06-01 00:00:00', 1, '2022-06-06 00:00:00')
 
 -- TEST CLIENT DATA: Add data for default client here
 


### PR DESCRIPTION
Alex doesn't want an error message returned if the schedule fails to create, this now will create a task but from the front end will not return any errors if the schedule fails to set up. 