### PR TITLE
sfs-486: Only allow B invoices to generate schedules

### DIFF
--- a/adrs/00035-direct-debit-restrictions.md
+++ b/adrs/00035-direct-debit-restrictions.md
@@ -1,0 +1,38 @@
+# 35. Direct Debit API restrictions
+
+Date: 2026-04-13
+
+## Status
+
+Accepted
+
+## Context
+
+When the integration between Allpay, Payments, and Sirius was first implemented, the services were kept agnostic of their
+producers and consumers. For example, if Payments receives an event to close a Direct Debit, it would attempt to close it
+without being concerned as to why the event was triggered. Under event-driven architecture, this is correct from the perspective
+of the producer, but the consumer need more control of which events are processed, e.g. Sirius as the producer should broadcast 
+an event when the client is made inactive, but Payments as the consumer should check the client has a mandate before attempting 
+to close it.
+
+There was also an assumption that while events could be sent and received as a result of plausible actions, these actions 
+would never be possible due to other business rules. For instance, while 'invoice-created' events are sent for all invoices
+created in Sirius, AD fees are created before Direct Debit mandates are sent out, and final fees would be sent after the
+mandate has been cancelled, so neither _should_ result in a payment schedule being created. However, business rules are
+messier than expected and these unenforced restrictions can be bypassed, such as when an AD fee is created for a replacement
+order and the client still has an active mandate.
+
+## Decision
+
+Event consumers within the Payments service will implement additional checks to ensure the actions they take in response
+to events are appropriate. When receiving an event to close a Direct Debit, Payments will check if the client 
+has their payment method set to 'Direct Debit' before attempting to close it. If the client does not have an active mandate, 
+the event will be ignored. Similarly, when receiving an 'invoice-created' event, Payments will only attempt to create a 
+payment schedule if the invoice type is B2/B3, i.e. an annual invoice paid by Direct Debit.
+
+## Consequences
+
+This brings us better in line with event-driven architecture best practice. However, it does mean both developers and producer
+services need to be aware of the conditions the consumer (Payments) will check before taking action. For instance, if we
+decide replacement AD fees should be paid by Direct Debit where an existing mandate exists, the developer will need to
+understand where the accepted invoice types are hardcoded.

--- a/finance-api/cmd/api/handle_events.go
+++ b/finance-api/cmd/api/handle_events.go
@@ -26,7 +26,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) error {
 			if err != nil {
 				return err
 			}
-			err = s.service.CreateDirectDebitScheduleForInvoice(ctx, detail.ClientID)
+			err = s.service.CreateDirectDebitScheduleForInvoice(ctx, detail)
 			if err != nil {
 				return err
 			}

--- a/finance-api/cmd/api/handle_events_test.go
+++ b/finance-api/cmd/api/handle_events_test.go
@@ -28,7 +28,7 @@ func TestServer_handleEvents(t *testing.T) {
 			event: shared.Event{
 				Source:     "opg.supervision.sirius",
 				DetailType: "invoice-created",
-				Detail:     shared.InvoiceCreatedEvent{ClientID: 1},
+				Detail:     shared.InvoiceCreatedEvent{ClientID: 1, InvoiceID: 2, InvoiceType: shared.InvoiceTypeB2},
 			},
 			expectedErr:     nil,
 			expectedHandler: "ReapplyCredit",

--- a/finance-api/cmd/api/server.go
+++ b/finance-api/cmd/api/server.go
@@ -31,7 +31,7 @@ type Service interface {
 	CancelDirectDebitMandate(ctx context.Context, id int32, cancelMandate shared.CancelMandate) error
 	CreateDirectDebitMandate(ctx context.Context, id int32, createMandate shared.CreateMandate) error
 	CreateDirectDebitSchedule(ctx context.Context, clientID int32, data shared.CreateSchedule) (service.PendingCollection, error)
-	CreateDirectDebitScheduleForInvoice(ctx context.Context, clientID int32) error
+	CreateDirectDebitScheduleForInvoice(ctx context.Context, details shared.InvoiceCreatedEvent) error
 	CheckPaymentMethod(ctx context.Context, clientID int32) error
 	ExpireRefunds(ctx context.Context) error
 	GetAccountInformation(ctx context.Context, id int32) (*shared.AccountInformation, error)

--- a/finance-api/cmd/api/server_test.go
+++ b/finance-api/cmd/api/server_test.go
@@ -215,7 +215,7 @@ func (s *mockService) SendDirectDebitCollectionEvent(ctx context.Context, id int
 	return s.errs["SendDirectDebitCollectionEvent"]
 }
 
-func (s *mockService) CreateDirectDebitScheduleForInvoice(ctx context.Context, clientID int32) error {
+func (s *mockService) CreateDirectDebitScheduleForInvoice(ctx context.Context, details shared.InvoiceCreatedEvent) error {
 	s.called = append(s.called, "CreateDirectDebitScheduleForInvoice")
 	return s.errs["CreateDirectDebitScheduleForInvoice"]
 }

--- a/finance-api/internal/service/create_dd_schedule_for_invoice.go
+++ b/finance-api/internal/service/create_dd_schedule_for_invoice.go
@@ -9,17 +9,21 @@ import (
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 )
 
-func (s *Service) CreateDirectDebitScheduleForInvoice(ctx context.Context, clientID int32) error {
+func (s *Service) CreateDirectDebitScheduleForInvoice(ctx context.Context, details shared.InvoiceCreatedEvent) error {
 	var err error
 
 	logger := s.Logger(ctx)
 
 	if !s.env.AllpayEnabled {
-		logger.Info(fmt.Sprintf("skipping Direct Debit schedule creation for client id %d as Allpay is disabled in this environment", clientID))
+		logger.Info(fmt.Sprintf("skipping Direct Debit schedule creation for client id %d as Allpay is disabled in this environment", details.ClientID))
 		return nil
 	}
 
-	client, err := s.store.GetClientById(ctx, clientID)
+	if !details.InvoiceType.IsDirectDebitInvoice() {
+		return nil
+	}
+
+	client, err := s.store.GetClientById(ctx, details.ClientID)
 	if err != nil {
 		return err
 	}
@@ -27,8 +31,8 @@ func (s *Service) CreateDirectDebitScheduleForInvoice(ctx context.Context, clien
 		return nil
 	}
 
-	if s.pendingScheduleExists(ctx, clientID) {
-		logger.Info(fmt.Sprintf("skipping Direct Debit schedule creation for client %d as a schedule already exists", clientID))
+	if s.pendingScheduleExists(ctx, details.ClientID) {
+		logger.Info(fmt.Sprintf("skipping Direct Debit schedule creation for client %d as a schedule already exists", details.ClientID))
 		return nil
 	}
 
@@ -36,7 +40,7 @@ func (s *Service) CreateDirectDebitScheduleForInvoice(ctx context.Context, clien
 		Surname:         client.Surname.String,
 		ClientReference: client.CourtRef.String,
 	}
-	_, err = s.CreateDirectDebitSchedule(ctx, clientID, shared.CreateSchedule{AllPayCustomer: allPayCustomer})
+	_, err = s.CreateDirectDebitSchedule(ctx, details.ClientID, shared.CreateSchedule{AllPayCustomer: allPayCustomer})
 	if err != nil {
 		return err
 	}

--- a/finance-api/internal/service/create_dd_schedule_for_invoice_test.go
+++ b/finance-api/internal/service/create_dd_schedule_for_invoice_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/allpay"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/store"
+	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,7 +25,30 @@ func (suite *IntegrationSuite) TestService_CreateDirectDebitSchedule_SkipsDemand
 	govUKMock := &mockGovUK{}
 	s := Service{store: store.New(seeder.Conn), allpay: allPayMock, govUK: govUKMock, tx: seeder.Conn, env: &Env{AllpayEnabled: true}}
 
-	err := s.CreateDirectDebitScheduleForInvoice(ctx, 11)
+	err := s.CreateDirectDebitScheduleForInvoice(ctx, shared.InvoiceCreatedEvent{ClientID: 11, InvoiceID: 1, InvoiceType: shared.InvoiceTypeB2})
+	assert.Nil(suite.T(), err)
+
+	var c int
+	_ = seeder.QueryRow(ctx, "SELECT COUNT(*) FROM pending_collection").Scan(&c)
+	assert.Equal(suite.T(), 0, c)
+	assert.Len(suite.T(), allPayMock.called, 0)
+}
+
+func (suite *IntegrationSuite) TestService_CreateDirectDebitScheduleForInvoice_SkipsNonDirectDebitInvoiceType() {
+	ctx := suite.ctx
+	seeder := suite.cm.Seeder(ctx, suite.T())
+
+	seeder.SeedData(
+		"INSERT INTO public.persons VALUES (11, NULL, NULL, 'Scheduleson', NULL, NULL, NULL, NULL, FALSE, FALSE, NULL, NULL, 'Client', NULL);",
+		"INSERT INTO finance_client (id, client_id, sop_number, payment_method, batchnumber, court_ref) VALUES (1, 11, '1234', 'DIRECT DEBIT', NULL, '1234567T');",
+		"INSERT INTO invoice VALUES (1, 11, 1, 'S2', 'S200123/24', '2024-01-01', '2025-03-31', 5000, NULL, '2024-01-01', NULL, '2024-01-01')",
+	)
+
+	allPayMock := &mockAllpay{}
+	govUKMock := &mockGovUK{}
+	s := Service{store: store.New(seeder.Conn), allpay: allPayMock, govUK: govUKMock, tx: seeder.Conn, env: &Env{AllpayEnabled: true}}
+
+	err := s.CreateDirectDebitScheduleForInvoice(ctx, shared.InvoiceCreatedEvent{ClientID: 11, InvoiceID: 1, InvoiceType: shared.InvoiceTypeS2})
 	assert.Nil(suite.T(), err)
 
 	var c int
@@ -50,7 +74,7 @@ func (suite *IntegrationSuite) TestService_CreateDirectDebitScheduleForInvoice()
 
 	s := Service{store: store.New(seeder.Conn), allpay: allPayMock, govUK: govUKMock, tx: seeder.Conn, dispatch: dispatchMock, env: &Env{AllpayEnabled: true}}
 
-	err := s.CreateDirectDebitScheduleForInvoice(ctx, 11)
+	err := s.CreateDirectDebitScheduleForInvoice(ctx, shared.InvoiceCreatedEvent{ClientID: 11, InvoiceID: 1, InvoiceType: shared.InvoiceTypeB2})
 
 	assert.Nil(suite.T(), err)
 
@@ -112,7 +136,7 @@ func (suite *IntegrationSuite) TestService_CreateDirectDebitScheduleForInvoice_s
 		"ALTER SEQUENCE supervision_finance.pending_collection_id_seq RESTART WITH 2",
 	)
 
-	err := s.CreateDirectDebitScheduleForInvoice(ctx, 11)
+	err := s.CreateDirectDebitScheduleForInvoice(ctx, shared.InvoiceCreatedEvent{ClientID: 11, InvoiceID: 1, InvoiceType: shared.InvoiceTypeB2})
 	assert.Nil(suite.T(), err)
 
 	var c int

--- a/shared/event.go
+++ b/shared/event.go
@@ -93,7 +93,9 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 }
 
 type InvoiceCreatedEvent struct {
-	ClientID int32 `json:"clientId"`
+	ClientID    int32       `json:"clientId"`
+	InvoiceID   int32       `json:"invoiceId"`
+	InvoiceType InvoiceType `json:"invoiceType"`
 }
 
 type ClientCreatedEvent struct {

--- a/shared/invoice_type.go
+++ b/shared/invoice_type.go
@@ -162,3 +162,12 @@ func (i InvoiceType) AllowsFutureRaisedDateValidation() bool {
 		return true
 	}
 }
+
+func (i InvoiceType) IsDirectDebitInvoice() bool {
+	switch i {
+	case InvoiceTypeB2, InvoiceTypeB3:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Invoice types that can generate direct debit payment schedules hardcoded to prevent other invoice types such as replacement AD fees from generating when there is ambiguity over whether these should happen automatically