### PR TITLE
sfs-549: Payments adhoc scripts

### DIFF
--- a/finance-api/cmd/api/process_adhoc_event.go
+++ b/finance-api/cmd/api/process_adhoc_event.go
@@ -2,17 +2,12 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 )
 
 func (s *Server) processAdhocEvent(ctx context.Context, event shared.AdhocEvent) error {
-	if event.Task != "InvalidatePendingCollections" {
-		return fmt.Errorf("invalid adhoc process: %s", event.Task)
-	}
-
-	err := s.service.ProcessAdhocEvent(ctx)
+	err := s.service.ProcessAdhocEvent(ctx, event)
 	if err != nil {
 		return err
 	}

--- a/finance-api/cmd/api/process_adhoc_event_test.go
+++ b/finance-api/cmd/api/process_adhoc_event_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/ministryofjustice/opg-go-common/telemetry"
@@ -20,37 +19,23 @@ func Test_processAdhocEvent(t *testing.T) {
 	service := &mockService{}
 
 	server := NewServer(service, nil, nil, nil, nil, nil, nil)
+	err := server.processAdhocEvent(ctx, shared.AdhocEvent{
+		Task: "SomeEvent",
+	})
+	assert.Nil(t, err)
+}
 
-	tests := []struct {
-		name             string
-		adhocProcessName shared.AdhocEvent
-		expectedResponse error
-		hasError         bool
-	}{
-		{
-			name: "Unknown report",
-			adhocProcessName: shared.AdhocEvent{
-				Task: "unknown",
-			},
-			expectedResponse: fmt.Errorf("invalid adhoc process: unknown"),
-			hasError:         true,
-		},
-		{
-			name: "adhoc event",
-			adhocProcessName: shared.AdhocEvent{
-				Task: "InvalidatePendingCollections",
-			},
-			expectedResponse: nil,
-			hasError:         false,
-		},
+func Test_processAdhocEvent_error(t *testing.T) {
+	ctx := auth.Context{
+		Context: telemetry.ContextWithLogger(context.Background(), telemetry.NewLogger("finance-api-test")),
+		User:    &shared.User{ID: 1},
 	}
-	for _, tt := range tests {
-		err := server.processAdhocEvent(ctx, shared.AdhocEvent{
-			Task: tt.adhocProcessName.Task,
-		})
-		if tt.hasError {
-			assert.Error(t, err)
-		}
-		assert.Equal(t, tt.expectedResponse, err)
-	}
+
+	service := &mockService{errs: map[string]error{"ProcessAdhocEvent": assert.AnError}}
+
+	server := NewServer(service, nil, nil, nil, nil, nil, nil)
+	err := server.processAdhocEvent(ctx, shared.AdhocEvent{
+		Task: "SomeEvent",
+	})
+	assert.Error(t, err)
 }

--- a/finance-api/cmd/api/server.go
+++ b/finance-api/cmd/api/server.go
@@ -43,7 +43,7 @@ type Service interface {
 	GetPermittedAdjustments(ctx context.Context, invoiceId int32) ([]shared.AdjustmentType, error)
 	GetRefunds(ctx context.Context, clientId int32) (shared.Refunds, error)
 	PostReportActions(ctx context.Context, report shared.ReportRequest)
-	ProcessAdhocEvent(ctx context.Context) error
+	ProcessAdhocEvent(ctx context.Context, event shared.AdhocEvent) error
 	ProcessDirectUploadReport(ctx context.Context, filename string, fileBytes io.Reader, uploadType shared.ReportUploadType) error
 	ProcessFailedDirectDebitCollections(ctx context.Context, date time.Time) error
 	ProcessFulfilledRefunds(ctx context.Context, records [][]string, date shared.Date) (map[int]string, error)

--- a/finance-api/cmd/api/server_test.go
+++ b/finance-api/cmd/api/server_test.go
@@ -40,7 +40,7 @@ func (s *mockService) AddCollectedPayments(ctx context.Context, date time.Time) 
 	return s.errs["AddCollectedPayments"]
 }
 
-func (s *mockService) ProcessAdhocEvent(ctx context.Context) error {
+func (s *mockService) ProcessAdhocEvent(ctx context.Context, event shared.AdhocEvent) error {
 	s.called = append(s.called, "ProcessAdhocEvent")
 	return s.errs["ProcessAdhocEvent"]
 }

--- a/finance-api/internal/service/process_adhoc_event.go
+++ b/finance-api/internal/service/process_adhoc_event.go
@@ -67,6 +67,7 @@ func (s *Service) processAdhocSetDemanded(ctx context.Context) {
 			20114931,
 			20090340,
 			10478906,
+			20104998,
 		}
 
 		//replaced context.Background with ctx to avoid cancellation, deadlines and logging context.

--- a/finance-api/internal/service/process_adhoc_event.go
+++ b/finance-api/internal/service/process_adhoc_event.go
@@ -5,26 +5,88 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/ministryofjustice/opg-go-common/telemetry"
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/auth"
+	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/store"
+	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 )
 
-func (s *Service) ProcessAdhocEvent(ctx context.Context) error {
+func (s *Service) ProcessAdhocEvent(ctx context.Context, event shared.AdhocEvent) error {
+	switch event.Task {
+	case "ChangePendingCollectionDate":
+		s.processAdhocChangePendingCollectionDate(ctx)
+	case "SetDemanded":
+		s.processAdhocSetDemanded(ctx)
+	default:
+		return fmt.Errorf("invalid adhoc process: %s", event.Task)
+	}
+	return nil
+}
+
+func (s *Service) processAdhocChangePendingCollectionDate(ctx context.Context) {
 	// perform async so request context doesn't cancel before process is complete
 	go func(logger *slog.Logger) {
-		logger.Info("InvalidatePendingCollections: started")
+		logger.Info("ChangePendingCollectionDate: started")
 
 		//replaced context.Background with ctx to avoid cancellation, deadlines and logging context.
 		funcCtx := telemetry.ContextWithLogger(ctx, logger)
 		funcCtx = ctx.(auth.Context).WithContext(funcCtx)
-		count, err := s.store.PurgePendingCollections(funcCtx)
+		count, err := s.store.ChangePendingCollectionDate(funcCtx)
 		if err != nil {
-			logger.Error("InvalidatePendingCollections: failed", "error", err)
+			logger.Error("ChangePendingCollectionDate: failed", "error", err)
 			return
 		}
 
-		logger.Info(fmt.Sprintf("InvalidatePendingCollections: %d pending collections deleted", count))
+		logger.Info(fmt.Sprintf("ChangePendingCollectionDate: %d pending collections updated", count))
 	}(telemetry.LoggerFromContext(ctx))
+}
 
-	return nil
+func (s *Service) processAdhocSetDemanded(ctx context.Context) {
+	// perform async so request context doesn't cancel before process is complete
+	go func(logger *slog.Logger) {
+		logger.Info("SetDemanded: started")
+
+		clientIDs := []int{
+			59290959,
+			20051524,
+			20044715,
+			20083594,
+			20098074,
+			46667347,
+			13475723,
+			12884246,
+			20090340,
+			20043623,
+		}
+
+		//replaced context.Background with ctx to avoid cancellation, deadlines and logging context.
+		funcCtx := telemetry.ContextWithLogger(ctx, logger)
+		funcCtx = ctx.(auth.Context).WithContext(funcCtx)
+
+		var count int
+		for _, cid := range clientIDs {
+			var (
+				paymentMethod pgtype.Text
+				id            pgtype.Int4
+				createdBy     pgtype.Int4
+			)
+			_ = paymentMethod.Scan(shared.PaymentMethodDemanded.Key())
+			_ = store.ToInt4(&id, cid)
+			_ = store.ToInt4(&createdBy, 2180)
+
+			// update payment method first, in case this fails
+			err := s.store.SetPaymentMethod(funcCtx, store.SetPaymentMethodParams{
+				PaymentMethod: paymentMethod,
+				ClientID:      id,
+				CreatedBy:     createdBy,
+			})
+			if err != nil {
+				logger.Error("SetDemanded: failed", "error", err, "clientID", cid)
+			}
+			count++
+		}
+
+		logger.Info(fmt.Sprintf("SetDemanded: %d clients set to demanded", count))
+	}(telemetry.LoggerFromContext(ctx))
 }

--- a/finance-api/internal/service/process_adhoc_event.go
+++ b/finance-api/internal/service/process_adhoc_event.go
@@ -58,6 +58,15 @@ func (s *Service) processAdhocSetDemanded(ctx context.Context) {
 			12884246,
 			20090340,
 			20043623,
+			20051524,
+			20044715,
+			20083594,
+			20098074,
+			13811367,
+			40131241,
+			20114931,
+			20090340,
+			10478906,
 		}
 
 		//replaced context.Background with ctx to avoid cancellation, deadlines and logging context.

--- a/finance-api/internal/service/process_adhoc_event_test.go
+++ b/finance-api/internal/service/process_adhoc_event_test.go
@@ -4,18 +4,29 @@ import (
 	"time"
 
 	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/finance-api/internal/store"
+	"github.com/ministryofjustice/opg-sirius-supervision-finance-hub/shared"
 	"github.com/stretchr/testify/assert"
 )
 
-func (suite *IntegrationSuite) Test_processAdhocEvent() {
+func (suite *IntegrationSuite) Test_processAdhocEvent_unknownTask() {
+	ctx := suite.ctx
+	seeder := suite.cm.Seeder(ctx, suite.T())
+
+	s := Service{store: store.New(seeder.Conn), tx: seeder.Conn}
+
+	err := s.ProcessAdhocEvent(ctx, shared.AdhocEvent{Task: "unknown"})
+	assert.ErrorContains(suite.T(), err, "invalid adhoc process: unknown")
+}
+
+func (suite *IntegrationSuite) Test_processAdhocEvent_changePendingCollectionDate() {
 	ctx := suite.ctx
 	seeder := suite.cm.Seeder(ctx, suite.T())
 
 	seeder.SeedData(
 		"INSERT INTO finance_client VALUES (1, 1, 'no-invoice', 'DEMANDED', NULL);",
-		"INSERT INTO pending_collection VALUES (1, 1, '2024-01-01', 8000, 'PENDING', NULL, '2024-01-01', 1);",
-		"INSERT INTO pending_collection VALUES (2, 1, '2024-01-01', 8000, 'COLLECTED', NULL, '2024-01-01', 1);",
-		"INSERT INTO pending_collection VALUES (3, 1, '2024-01-01', 8000, 'CANCELLED', NULL, '2024-01-01', 1);",
+		"INSERT INTO pending_collection VALUES (1, 1, '2026-05-25', 8000, 'PENDING', NULL, '2024-01-01', 1);",
+		"INSERT INTO pending_collection VALUES (2, 1, '2026-05-25', 8000, 'COLLECTED', NULL, '2024-01-01', 1);",
+		"INSERT INTO pending_collection VALUES (3, 1, '2026-05-25', 8000, 'CANCELLED', NULL, '2024-01-01', 1);",
 	)
 	dispatch := &mockDispatch{}
 	s := Service{store: store.New(seeder.Conn), dispatch: dispatch, tx: seeder.Conn}
@@ -25,12 +36,12 @@ func (suite *IntegrationSuite) Test_processAdhocEvent() {
 	_ = seeder.QueryRow(ctx, "SELECT COUNT(*) FROM pending_collection;").Scan(&count)
 	assert.Equal(suite.T(), 3, count)
 
-	err := s.ProcessAdhocEvent(ctx)
+	err := s.ProcessAdhocEvent(ctx, shared.AdhocEvent{Task: "ChangePendingCollectionDate"})
 	assert.Nil(suite.T(), err)
 
 	// wait for async process
 	time.Sleep(1 * time.Second)
 
-	_ = seeder.QueryRow(ctx, "SELECT COUNT(*) FROM pending_collection;").Scan(&count)
-	assert.Equal(suite.T(), 1, count)
+	_ = seeder.QueryRow(ctx, "SELECT COUNT(*) FROM pending_collection WHERE collection_date = '2026-05-26';").Scan(&count)
+	assert.Equal(suite.T(), 3, count)
 }

--- a/finance-api/internal/store/adhoc.sql.go
+++ b/finance-api/internal/store/adhoc.sql.go
@@ -9,12 +9,14 @@ import (
 	"context"
 )
 
-const purgePendingCollections = `-- name: PurgePendingCollections :execrows
-DELETE FROM pending_collection WHERE status <> 'COLLECTED'
+const changePendingCollectionDate = `-- name: ChangePendingCollectionDate :execrows
+UPDATE pending_collection
+SET collection_date = '2026-05-26'
+WHERE collection_date = '2026-05-25'
 `
 
-func (q *Queries) PurgePendingCollections(ctx context.Context) (int64, error) {
-	result, err := q.db.Exec(ctx, purgePendingCollections)
+func (q *Queries) ChangePendingCollectionDate(ctx context.Context) (int64, error) {
+	result, err := q.db.Exec(ctx, changePendingCollectionDate)
 	if err != nil {
 		return 0, err
 	}

--- a/finance-api/internal/store/queries/adhoc.sql
+++ b/finance-api/internal/store/queries/adhoc.sql
@@ -1,2 +1,4 @@
--- name: PurgePendingCollections :execrows
-DELETE FROM pending_collection WHERE status <> 'COLLECTED';
+-- name: ChangePendingCollectionDate :execrows
+UPDATE pending_collection
+SET collection_date = '2026-05-26'
+WHERE collection_date = '2026-05-25';


### PR DESCRIPTION
Creates two new adhoc event scripts - one to update pending collection dates, and one to mark some clients as demanded - that can be run independently